### PR TITLE
Fix process.env leaking unsanitized secrets to child processes

### DIFF
--- a/src/tools/run-with-env.ts
+++ b/src/tools/run-with-env.ts
@@ -31,13 +31,26 @@ export async function runWithEnv(
     }
   }
 
+  // Only pass through safe, non-secret process env vars needed for commands to work.
+  // This prevents the MCP server's own environment secrets from leaking unsanitized.
+  const safeProcessEnv: Record<string, string> = {};
+  const SAFE_KEYS = [
+    "PATH", "HOME", "SHELL", "USER", "LOGNAME", "TERM", "LANG",
+    "LC_ALL", "LC_CTYPE", "TMPDIR", "XDG_RUNTIME_DIR",
+  ];
+  for (const key of SAFE_KEYS) {
+    if (process.env[key]) {
+      safeProcessEnv[key] = process.env[key] as string;
+    }
+  }
+
   return new Promise((resolve) => {
     const child = execFile(
       "/bin/sh",
       ["-c", args.command],
       {
         cwd: args.project_dir,
-        env: { ...process.env, ...injectedEnv },
+        env: { ...safeProcessEnv, ...injectedEnv },
         timeout: args.timeout_ms,
         maxBuffer: 1024 * 1024,
       },


### PR DESCRIPTION
## Summary

- Replace full `process.env` spread with a safe allowlist (`PATH`, `HOME`, `SHELL`, `USER`, `LOGNAME`, `TERM`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TMPDIR`, `XDG_RUNTIME_DIR`)
- Prevents the MCP server's own environment secrets (AWS creds, tokens, etc.) from being passed to child processes and appearing unsanitized in output

Closes #1

## Test plan

- [ ] Run a command that prints env vars (e.g. `env` or `printenv`) and verify only allowlisted keys appear
- [ ] Verify `.env` values are still injected and redacted in output
- [ ] Verify commands that need `PATH` (e.g. `node`, `git`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)