### PR TITLE
Fix critical and high severity security vulnerabilities

### DIFF
--- a/src/security/path-validator.ts
+++ b/src/security/path-validator.ts
@@ -1,0 +1,45 @@
+import { isAbsolute } from "node:path";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const PROJECT_MARKERS = [
+  ".git",
+  "package.json",
+  "Cargo.toml",
+  "go.mod",
+  "pyproject.toml",
+  "Gemfile",
+  "pom.xml",
+  "build.gradle",
+  "Makefile",
+  "CMakeLists.txt",
+  ".env",
+  "composer.json",
+  "requirements.txt",
+  "setup.py",
+];
+
+export function validateProjectDir(dir: string): {
+  valid: boolean;
+  reason?: string;
+} {
+  if (!isAbsolute(dir)) {
+    return {
+      valid: false,
+      reason: "project_dir must be an absolute path",
+    };
+  }
+
+  const hasMarker = PROJECT_MARKERS.some((marker) =>
+    existsSync(join(dir, marker))
+  );
+
+  if (!hasMarker) {
+    return {
+      valid: false,
+      reason: `project_dir must contain a project marker file (${PROJECT_MARKERS.slice(0, 5).join(", ")}, ...)`,
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -1,0 +1,79 @@
+import { lookup } from "node:dns/promises";
+
+const BLOCKED_IP_RANGES = [
+  // Loopback
+  /^127\./,
+  /^::1$/,
+  /^0\.0\.0\.0$/,
+  // Private networks
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  // Link-local (cloud metadata)
+  /^169\.254\./,
+  // IPv6 private
+  /^fe80:/i,
+  /^fc00:/i,
+  /^fd[0-9a-f]{2}:/i,
+];
+
+const BLOCKED_SCHEMES = ["file:", "ftp:", "gopher:", "data:"];
+
+function isPrivateIp(ip: string): boolean {
+  return BLOCKED_IP_RANGES.some((pattern) => pattern.test(ip));
+}
+
+export async function validateUrl(url: string): Promise<{
+  allowed: boolean;
+  reason?: string;
+}> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { allowed: false, reason: "Invalid URL" };
+  }
+
+  // Block dangerous schemes
+  if (BLOCKED_SCHEMES.includes(parsed.protocol)) {
+    return {
+      allowed: false,
+      reason: `Blocked scheme: ${parsed.protocol}`,
+    };
+  }
+
+  // Only allow http/https
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      allowed: false,
+      reason: `Only http and https schemes are allowed, got: ${parsed.protocol}`,
+    };
+  }
+
+  // Check if hostname is already an IP
+  const hostname = parsed.hostname;
+  if (isPrivateIp(hostname)) {
+    return {
+      allowed: false,
+      reason: "Blocked: request to private/internal IP address",
+    };
+  }
+
+  // Resolve hostname and check the resolved IP
+  try {
+    const { address } = await lookup(hostname);
+    if (isPrivateIp(address)) {
+      return {
+        allowed: false,
+        reason: `Blocked: ${hostname} resolves to private IP ${address}`,
+      };
+    }
+  } catch {
+    return {
+      allowed: false,
+      reason: `DNS resolution failed for ${hostname}`,
+    };
+  }
+
+  return { allowed: true };
+}

--- a/src/tools/api-call.ts
+++ b/src/tools/api-call.ts
@@ -1,9 +1,15 @@
 import { z } from "zod";
+import { isAbsolute } from "node:path";
 import { loadEnv } from "../env-loader.js";
 import { sanitize } from "../utils/sanitize.js";
+import { validateUrl } from "../security/url-validator.js";
+import { validateProjectDir } from "../security/path-validator.js";
 
 export const ApiCallSchema = z.object({
-  project_dir: z.string().describe("Absolute path to the project directory"),
+  project_dir: z
+    .string()
+    .refine((p) => isAbsolute(p), "project_dir must be an absolute path")
+    .describe("Absolute path to the project directory"),
   url: z.string().url().describe("Request URL"),
   method: z
     .enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
@@ -36,6 +42,22 @@ function interpolateHeaders(
 export async function apiCall(
   args: z.infer<typeof ApiCallSchema>
 ): Promise<{ status: number; headers: Record<string, string>; body: string }> {
+  // Path traversal protection
+  const pathCheck = validateProjectDir(args.project_dir);
+  if (!pathCheck.valid) {
+    return { status: 0, headers: {}, body: `Error: ${pathCheck.reason}` };
+  }
+
+  // SSRF protection: block requests to private/internal IPs
+  const urlCheck = await validateUrl(args.url);
+  if (!urlCheck.allowed) {
+    return {
+      status: 0,
+      headers: {},
+      body: `Request blocked: ${urlCheck.reason}`,
+    };
+  }
+
   const env = loadEnv(args.project_dir);
 
   const headers: Record<string, string> = args.headers
@@ -55,7 +77,7 @@ export async function apiCall(
   const bodyText = await response.text();
   const responseHeaders: Record<string, string> = {};
   response.headers.forEach((value, key) => {
-    responseHeaders[key] = value;
+    responseHeaders[key] = sanitize(value, env);
   });
 
   return {

--- a/src/tools/get-env-keys.ts
+++ b/src/tools/get-env-keys.ts
@@ -1,13 +1,23 @@
 import { z } from "zod";
+import { isAbsolute } from "node:path";
 import { loadEnv } from "../env-loader.js";
+import { validateProjectDir } from "../security/path-validator.js";
 
 export const GetEnvKeysSchema = z.object({
-  project_dir: z.string().describe("Absolute path to the project directory"),
+  project_dir: z
+    .string()
+    .refine((p) => isAbsolute(p), "project_dir must be an absolute path")
+    .describe("Absolute path to the project directory"),
 });
 
 export async function getEnvKeys(
   args: z.infer<typeof GetEnvKeysSchema>
-): Promise<{ keys: string[] }> {
+): Promise<{ keys: string[] } | { error: string }> {
+  const pathCheck = validateProjectDir(args.project_dir);
+  if (!pathCheck.valid) {
+    return { error: pathCheck.reason! };
+  }
+
   const env = loadEnv(args.project_dir);
   return { keys: Object.keys(env) };
 }

--- a/src/tools/run-with-env.ts
+++ b/src/tools/run-with-env.ts
@@ -1,10 +1,15 @@
 import { z } from "zod";
+import { isAbsolute } from "node:path";
 import { execFile } from "node:child_process";
 import { loadEnv } from "../env-loader.js";
 import { sanitize } from "../utils/sanitize.js";
+import { validateProjectDir } from "../security/path-validator.js";
 
 export const RunWithEnvSchema = z.object({
-  project_dir: z.string().describe("Absolute path to the project directory"),
+  project_dir: z
+    .string()
+    .refine((p) => isAbsolute(p), "project_dir must be an absolute path")
+    .describe("Absolute path to the project directory"),
   command: z.string().describe("Shell command to execute"),
   env_keys: z
     .array(z.string())
@@ -19,7 +24,14 @@ export const RunWithEnvSchema = z.object({
 
 export async function runWithEnv(
   args: z.infer<typeof RunWithEnvSchema>
-): Promise<{ exit_code: number; stdout: string; stderr: string }> {
+): Promise<
+  { exit_code: number; stdout: string; stderr: string } | { error: string }
+> {
+  const pathCheck = validateProjectDir(args.project_dir);
+  if (!pathCheck.valid) {
+    return { error: pathCheck.reason! };
+  }
+
   const env = loadEnv(args.project_dir);
 
   // Filter to requested keys if specified

--- a/src/tools/sync-example.ts
+++ b/src/tools/sync-example.ts
@@ -1,9 +1,14 @@
 import { z } from "zod";
+import { isAbsolute } from "node:path";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { validateProjectDir } from "../security/path-validator.js";
 
 export const SyncExampleSchema = z.object({
-  project_dir: z.string().describe("Absolute path to the project directory"),
+  project_dir: z
+    .string()
+    .refine((p) => isAbsolute(p), "project_dir must be an absolute path")
+    .describe("Absolute path to the project directory"),
 });
 
 function smartPlaceholder(key: string, value: string): string {
@@ -51,7 +56,12 @@ function parseExistingExample(
 
 export async function syncExample(
   args: z.infer<typeof SyncExampleSchema>
-): Promise<{ path: string; keys_synced: number }> {
+): Promise<{ path: string; keys_synced: number } | { error: string }> {
+  const pathCheck = validateProjectDir(args.project_dir);
+  if (!pathCheck.valid) {
+    return { error: pathCheck.reason! };
+  }
+
   const envPath = join(args.project_dir, ".env");
   const examplePath = join(args.project_dir, ".env.example");
 

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -4,7 +4,7 @@ export function sanitize(
 ): string {
   // Build replacements sorted longest-first to avoid partial matches
   const replacements = Object.entries(env)
-    .filter(([, value]) => value.length > 4)
+    .filter(([, value]) => value.length > 2)
     .sort((a, b) => b[1].length - a[1].length);
 
   let result = text;


### PR DESCRIPTION
## Summary

Addresses the 5 most severe open issues with non-breaking, additive fixes:

- **#2 CRITICAL** — Response headers in `api_call` are now sanitized (previously returned raw, leaking server-echoed auth tokens)
- **#3 HIGH** — Sanitize threshold lowered from `> 4` to `> 2` chars (catches short secrets like `root`, `3306`, `true`)
- **#5 HIGH** — SSRF protection added to `api_call`: resolves hostnames before fetch and blocks private IP ranges (10.x, 172.16-31.x, 192.168.x, 127.x, 169.254.x/cloud metadata), loopback, link-local, and non-http schemes
- **#4 HIGH** — Path traversal protection: `project_dir` must now contain a project marker file (`.git`, `package.json`, `Cargo.toml`, etc.) preventing reads from `~/.aws/`, `/etc/`, or other projects
- **#9 LOW** — Zod schema refinement enforces absolute paths at the validation layer

All changes are backward-compatible for normal usage — the only requests that break are ones that *should* have been blocked.

### New files
- `src/security/url-validator.ts` — DNS-aware SSRF protection with private IP blocking
- `src/security/path-validator.ts` — Project directory validation with marker file detection

### Modified files
- `src/tools/api-call.ts` — Header sanitization + SSRF + path validation
- `src/tools/run-with-env.ts` — Path validation
- `src/tools/get-env-keys.ts` — Path validation
- `src/tools/sync-example.ts` — Path validation
- `src/utils/sanitize.ts` — Lowered threshold

## Test plan

- [ ] `api_call` to `http://169.254.169.254/latest/meta-data/` → blocked
- [ ] `api_call` to `http://localhost:8080` → blocked
- [ ] `api_call` to `file:///etc/passwd` → blocked
- [ ] `project_dir=/etc` → rejected (no project marker)
- [ ] `project_dir=./relative` → rejected (not absolute)
- [ ] API that echoes auth in `Set-Cookie` header → value is redacted
- [ ] `KEY=yes` in .env → output shows `[REDACTED:KEY]` instead of `yes`

Closes #2, #3, #4, #5, #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)