### PR TITLE
Fix IPv6 SSRF gaps and broken bracket handling in url-validator

### DIFF
--- a/src/security/url-validator.test.ts
+++ b/src/security/url-validator.test.ts
@@ -37,6 +37,21 @@ describe("validateUrl - existing IPv6 coverage (regression)", () => {
     expect(result.allowed).toBe(false);
   });
 
+  it("blocks fe90:: link-local (fe80::/10 range)", async () => {
+    const result = await validateUrl("http://[fe90::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks fea0:: link-local (fe80::/10 range)", async () => {
+    const result = await validateUrl("http://[fea0::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks feb0:: link-local (fe80::/10 range)", async () => {
+    const result = await validateUrl("http://[feb0::1]");
+    expect(result.allowed).toBe(false);
+  });
+
   it("blocks fc00:: unique local", async () => {
     const result = await validateUrl("http://[fc00::1]");
     expect(result.allowed).toBe(false);

--- a/src/security/url-validator.test.ts
+++ b/src/security/url-validator.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as dns from "node:dns/promises";
+
+// Mock dns.lookup so tests don't make real network calls
+vi.mock("node:dns/promises");
+const mockLookup = vi.mocked(dns.lookup);
+
+// Default: any hostname resolves to a public IP
+beforeEach(() => {
+  mockLookup.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+});
+
+// Import after mocking
+const { validateUrl } = await import("./url-validator.js");
+
+describe("validateUrl - IPv6 private ranges (missing coverage)", () => {
+  it("blocks 64:ff9b:: IPv4/IPv6 translation prefix (maps to private IPv4)", async () => {
+    // 64:ff9b::10.0.0.1 translates to 10.0.0.1 — a private address
+    const result = await validateUrl("http://[64:ff9b::a00:1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks 100:: IPv6 discard prefix", async () => {
+    const result = await validateUrl("http://[100::1]");
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe("validateUrl - existing IPv6 coverage (regression)", () => {
+  it("blocks ::1 loopback", async () => {
+    const result = await validateUrl("http://[::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks fe80:: link-local", async () => {
+    const result = await validateUrl("http://[fe80::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks fc00:: unique local", async () => {
+    const result = await validateUrl("http://[fc00::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks fd00:: unique local", async () => {
+    const result = await validateUrl("http://[fd00::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks ::ffff:127.0.0.1 IPv4-mapped loopback", async () => {
+    const result = await validateUrl("http://[::ffff:127.0.0.1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks ::ffff:192.168.1.1 IPv4-mapped private", async () => {
+    const result = await validateUrl("http://[::ffff:192.168.1.1]");
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe("validateUrl - private IPv4 (regression)", () => {
+  it("blocks 127.0.0.1", async () => {
+    expect((await validateUrl("http://127.0.0.1")).allowed).toBe(false);
+  });
+
+  it("blocks 10.0.0.1", async () => {
+    expect((await validateUrl("http://10.0.0.1")).allowed).toBe(false);
+  });
+
+  it("blocks 172.16.0.1", async () => {
+    expect((await validateUrl("http://172.16.0.1")).allowed).toBe(false);
+  });
+
+  it("blocks 172.31.255.255", async () => {
+    expect((await validateUrl("http://172.31.255.255")).allowed).toBe(false);
+  });
+
+  it("blocks 192.168.1.1", async () => {
+    expect((await validateUrl("http://192.168.1.1")).allowed).toBe(false);
+  });
+
+  it("blocks 169.254.169.254 (cloud metadata)", async () => {
+    expect((await validateUrl("http://169.254.169.254")).allowed).toBe(false);
+  });
+});
+
+describe("validateUrl - scheme blocking (regression)", () => {
+  it("blocks file://", async () => {
+    expect((await validateUrl("file:///etc/passwd")).allowed).toBe(false);
+  });
+
+  it("blocks ftp://", async () => {
+    expect((await validateUrl("ftp://example.com")).allowed).toBe(false);
+  });
+
+  it("blocks javascript: (non-http)", async () => {
+    expect((await validateUrl("javascript://x")).allowed).toBe(false);
+  });
+});
+
+describe("validateUrl - allowed", () => {
+  it("allows a public hostname that resolves to a public IP", async () => {
+    const result = await validateUrl("https://example.com");
+    expect(result.allowed).toBe(true);
+    expect(result.resolvedIp).toBe("93.184.216.34");
+    expect(result.hostname).toBe("example.com");
+  });
+
+  it("blocks a hostname that resolves to a private IP (DNS rebinding)", async () => {
+    mockLookup.mockResolvedValue({ address: "192.168.1.1", family: 4 });
+    const result = await validateUrl("https://evil.example.com");
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -41,25 +41,50 @@ function isPrivateIpv4(ip: number): boolean {
 /**
  * Check if an IP address string is private/reserved.
  * Handles IPv4, IPv6 loopback, and IPv6 private ranges.
+ * Input must be a bare address without brackets.
  */
 function isPrivateIp(ip: string): boolean {
   // IPv6 loopback
   if (ip === "::1") return true;
-  // IPv6 link-local
+  // IPv6 link-local (fe80::/10)
   if (ip.toLowerCase().startsWith("fe80:")) return true;
-  // IPv6 unique local (fc00::/7)
+  // IPv6 unique local (fc00::/7 — covers fc:: and fd::)
   if (/^f[cd]/i.test(ip)) return true;
-  // IPv4-mapped IPv6 (::ffff:x.x.x.x)
+  // IPv6 NAT64 translation prefix (64:ff9b::/96 — maps to IPv4 space)
+  if (/^64:ff9b:/i.test(ip)) return true;
+  // IPv6 discard prefix (100::/64)
+  if (/^0*100:/i.test(ip)) return true;
+  // IPv4-mapped IPv6 — dotted-decimal form: ::ffff:x.x.x.x
   const v4mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
   if (v4mapped) {
     const parsed = parseIpv4(v4mapped[1]);
     if (parsed !== null) return isPrivateIpv4(parsed);
+  }
+  // IPv4-mapped IPv6 — hex form after URL normalization: ::ffff:xxxx:xxxx
+  // e.g. URL parser converts ::ffff:127.0.0.1 → ::ffff:7f00:1
+  const v4mappedHex = ip.match(/^::ffff:([0-9a-f]+):([0-9a-f]+)$/i);
+  if (v4mappedHex) {
+    const high = parseInt(v4mappedHex[1], 16);
+    const low = parseInt(v4mappedHex[2], 16);
+    const ipNum = (((high << 16) | low) >>> 0);
+    return isPrivateIpv4(ipNum);
   }
   // Plain IPv4
   const parsed = parseIpv4(ip);
   if (parsed !== null) return isPrivateIpv4(parsed);
 
   return false;
+}
+
+/**
+ * Strip IPv6 brackets from a URL hostname.
+ * URL.hostname returns "[::1]" for IPv6 literals — we need "::1" for isPrivateIp.
+ */
+function stripBrackets(hostname: string): string {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
 }
 
 export interface ValidatedUrl {
@@ -93,9 +118,12 @@ export async function validateUrl(url: string): Promise<ValidatedUrl> {
   }
 
   const hostname = parsed.hostname;
+  // URL.hostname includes brackets for IPv6 literals (e.g., "[::1]") —
+  // strip them before IP checks and DNS lookup.
+  const bareHostname = stripBrackets(hostname);
 
   // Check if hostname is already a literal IP
-  if (isPrivateIp(hostname)) {
+  if (isPrivateIp(bareHostname)) {
     return {
       allowed: false,
       reason: "Blocked: request to private/internal IP address",
@@ -104,14 +132,14 @@ export async function validateUrl(url: string): Promise<ValidatedUrl> {
 
   // Resolve hostname and check the resolved IP
   try {
-    const { address } = await lookup(hostname);
+    const { address } = await lookup(bareHostname);
     if (isPrivateIp(address)) {
       return {
         allowed: false,
         reason: `Blocked: ${hostname} resolves to private IP ${address}`,
       };
     }
-    return { allowed: true, resolvedIp: address, hostname };
+    return { allowed: true, resolvedIp: address, hostname: bareHostname };
   } catch {
     return {
       allowed: false,

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -46,8 +46,8 @@ function isPrivateIpv4(ip: number): boolean {
 function isPrivateIp(ip: string): boolean {
   // IPv6 loopback
   if (ip === "::1") return true;
-  // IPv6 link-local (fe80::/10)
-  if (ip.toLowerCase().startsWith("fe80:")) return true;
+  // IPv6 link-local (fe80::/10 — covers fe80:: through febf::)
+  if (/^fe[89ab][0-9a-f]:/i.test(ip)) return true;
   // IPv6 unique local (fc00::/7 — covers fc:: and fd::)
   if (/^f[cd]/i.test(ip)) return true;
   // IPv6 NAT64 translation prefix (64:ff9b::/96 — maps to IPv4 space)


### PR DESCRIPTION
## Summary

- Fixes #22: adds missing IPv6 private ranges (`64:ff9b::/96` NAT64, `100::/64` discard)
- Fixes a pre-existing bug where **all** IPv6 literal addresses in URLs bypassed `isPrivateIp` because `URL.hostname` returns `"[::1]"` (with brackets) not `"::1"`
- Fixes a second pre-existing bug where `::ffff:127.0.0.1` escaped detection because the URL parser normalizes it to hex form `::ffff:7f00:1`

## Changes

**`url-validator.ts`**
- `stripBrackets()` — strips `[` / `]` from IPv6 hostnames before IP checks and `dns.lookup`
- Second `::ffff:xxxx:xxxx` hex matcher for URL-normalized IPv4-mapped addresses
- New range checks: `64:ff9b::/96`, `100::/64`

**`url-validator.test.ts`** — 19 tests covering:
- All blocked IPv6 ranges (new and existing)
- All blocked private IPv4 ranges
- Scheme blocking
- DNS rebinding (hostname resolves to private IP)
- Allowed public hostname path

## Test plan

- [x] `npm test` passes (24/24)
- [x] All IPv6 literal URLs now correctly blocked
- [x] Public hostname still allowed