### PR TITLE
Block 6to4 and Teredo IPv6 tunneling SSRF vectors (closes #36)

### DIFF
--- a/src/security/url-validator.test.ts
+++ b/src/security/url-validator.test.ts
@@ -24,6 +24,44 @@ describe("validateUrl - IPv6 private ranges (missing coverage)", () => {
     const result = await validateUrl("http://[100::1]");
     expect(result.allowed).toBe(false);
   });
+
+  // 6to4: 2002::/16 — encodes IPv4 in bits 17-48 (groups 2 and 3)
+  it("blocks 2002:7f00:1:: (6to4 encoding of 127.0.0.1)", async () => {
+    const result = await validateUrl("http://[2002:7f00:1::]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks 2002:c0a8:101:: (6to4 encoding of 192.168.1.1)", async () => {
+    const result = await validateUrl("http://[2002:c0a8:101::]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks 2002:a00:1:: (6to4 encoding of 10.0.0.1)", async () => {
+    const result = await validateUrl("http://[2002:a00:1::]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("allows 2002:0808:0808:: (6to4 encoding of public 8.8.8.8)", async () => {
+    const result = await validateUrl("http://[2002:808:808::]");
+    expect(result.allowed).toBe(true);
+  });
+
+  // Teredo: 2001:0000::/32
+  it("blocks 2001:0000:: Teredo prefix", async () => {
+    const result = await validateUrl("http://[2001:0000::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks 2001:: Teredo prefix (abbreviated)", async () => {
+    const result = await validateUrl("http://[2001::1]");
+    expect(result.allowed).toBe(false);
+  });
+
+  // 2001:db8::/32 is documentation range — safe to block
+  it("blocks 2001:db8:: documentation prefix", async () => {
+    const result = await validateUrl("http://[2001:db8::1]");
+    expect(result.allowed).toBe(false);
+  });
 });
 
 describe("validateUrl - existing IPv6 coverage (regression)", () => {

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -54,6 +54,18 @@ function isPrivateIp(ip: string): boolean {
   if (/^64:ff9b:/i.test(ip)) return true;
   // IPv6 discard prefix (100::/64)
   if (/^0*100:/i.test(ip)) return true;
+  // 6to4 (2002::/16) — embeds IPv4 in bits 17-48 (hex groups 2 and 3)
+  // e.g. 2002:7f00:0001:: encodes 127.0.0.1
+  const sixToFour = ip.match(/^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4}):/i);
+  if (sixToFour) {
+    const high = parseInt(sixToFour[1], 16);
+    const low = parseInt(sixToFour[2], 16);
+    const ipNum = (((high << 16) | low) >>> 0);
+    if (isPrivateIpv4(ipNum)) return true;
+  }
+  // Teredo (2001:0000::/32) and documentation range (2001:db8::/32).
+  // URL parser normalizes 2001:0000::1 → 2001::1, so match 0* (including empty).
+  if (/^2001:(0*:|db8:)/i.test(ip)) return true;
   // IPv4-mapped IPv6 — dotted-decimal form: ::ffff:x.x.x.x
   const v4mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
   if (v4mapped) {


### PR DESCRIPTION
## Summary

- Blocks 6to4 (`2002::/16`) by extracting the embedded IPv4 address and checking it against private ranges — `2002:c0a8:101::` (192.168.1.1) is blocked, `2002:808:808::` (8.8.8.8) is allowed
- Blocks Teredo (`2001:0000::/32`) and documentation range (`2001:db8::/32`) conservatively
- Handles URL parser normalization: `2001:0000::1` → `2001::1` (uses `0*` in regex)

## Test plan

- [x] `npm test` passes (34/34)
- [x] Private 6to4 addresses blocked, public 6to4 allowed
- [x] Teredo prefix blocked in both explicit and abbreviated forms
- [x] `2001:db8::` documentation range blocked
- [x] All prior regression tests still pass