### PR TITLE
Fix stale cache when .env replaced with identical mtime (closes #27)

### DIFF
--- a/src/env-loader.test.ts
+++ b/src/env-loader.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "env-loader-test-"));
+}
+
+const temps: string[] = [];
+function tempDir(): string {
+  const dir = makeTempDir();
+  temps.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("loadEnv - basic", () => {
+  it("returns empty object when .env does not exist", async () => {
+    const { loadEnv } = await import("./env-loader.js");
+    const dir = tempDir();
+    expect(loadEnv(dir)).toEqual({});
+  });
+
+  it("parses key=value pairs from .env", async () => {
+    const { loadEnv } = await import("./env-loader.js");
+    const dir = tempDir();
+    writeFileSync(join(dir, ".env"), "API_KEY=secret\nPORT=3000\n");
+    expect(loadEnv(dir)).toEqual({ API_KEY: "secret", PORT: "3000" });
+  });
+});
+
+describe("loadEnv - stale cache (mtime collision)", () => {
+  it("returns updated values when content changes but mtime is identical", async () => {
+    const { loadEnv } = await import("./env-loader.js");
+    const dir = tempDir();
+    const envPath = join(dir, ".env");
+
+    // Pin both writes to the same known fixed timestamp so the mtime
+    // is guaranteed identical regardless of filesystem precision.
+    const fixedTime = new Date("2020-06-15T12:00:00.000Z");
+
+    writeFileSync(envPath, "API_KEY=original\n");
+    utimesSync(envPath, fixedTime, fixedTime);
+    const first = loadEnv(dir);
+    expect(first.API_KEY).toBe("original");
+
+    // Same mtime, different content — simulates coarse-clock / touch -t attack
+    writeFileSync(envPath, "API_KEY=rotated\n");
+    utimesSync(envPath, fixedTime, fixedTime);
+
+    // Must NOT serve stale cached value
+    const second = loadEnv(dir);
+    expect(second.API_KEY).toBe("rotated");
+  });
+});

--- a/src/env-loader.ts
+++ b/src/env-loader.ts
@@ -1,9 +1,11 @@
 import { readFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { parse } from "dotenv";
 
 interface CacheEntry {
   mtime: number;
+  contentHash: string;
   env: Record<string, string>;
 }
 
@@ -26,17 +28,20 @@ export function loadEnv(projectDir: string): Record<string, string> {
     mtime = statSync(envPath).mtimeMs;
   } catch {
     // File was deleted between read and stat — use what we read
-    const env = parse(content);
-    return env;
+    return parse(content);
   }
 
+  // Hash the content so identical-mtime replacements (coarse clock,
+  // touch -t, secret rotation scripts) are still detected.
+  const contentHash = createHash("sha256").update(content).digest("hex");
+
   const cached = cache.get(envPath);
-  if (cached && cached.mtime === mtime) {
+  if (cached && cached.mtime === mtime && cached.contentHash === contentHash) {
     return cached.env;
   }
 
   const env = parse(content);
-  cache.set(envPath, { mtime, env });
+  cache.set(envPath, { mtime, contentHash, env });
   return env;
 }
 


### PR DESCRIPTION
## Summary

- Adds a SHA-256 content hash to the `env-loader` cache key alongside `mtimeMs`
- Cache hit now requires both `mtime` AND `contentHash` to match
- Prevents stale secrets being served when `.env` is replaced with new content but mtime is unchanged (coarse filesystem clock, `touch -t`, secret rotation scripts)

## Changes

**`src/env-loader.ts`**
- Import `createHash` from `node:crypto`
- `CacheEntry` gains `contentHash: string` field
- Hash computed from already-read content — no extra I/O
- Cache check: `cached.mtime === mtime && cached.contentHash === contentHash`

**`src/env-loader.test.ts`** (new)
- Basic: missing file returns `{}`, key=value pairs parsed correctly
- Stale cache: pins both writes to a fixed timestamp via `utimesSync`, verifies updated content is returned despite identical mtime

## Test plan

- [x] `npm test` passes (37/37)
- [x] Stale cache test fails before fix, passes after