### PR TITLE
Fix audit double-count when auth_env_key and template headers overlap (closes #25)

### DIFF
--- a/src/tools/api-call.test.ts
+++ b/src/tools/api-call.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock modules before importing the module under test
+vi.mock("../security/audit.js");
+vi.mock("../security/url-validator.js");
+vi.mock("../env-loader.js");
+vi.mock("../security/path-validator.js");
+
+const { auditLog } = await import("../security/audit.js");
+const { validateUrl } = await import("../security/url-validator.js");
+const { loadEnv } = await import("../env-loader.js");
+const { validateProjectDir } = await import("../security/path-validator.js");
+const { apiCall } = await import("./api-call.js");
+
+const mockAuditLog = vi.mocked(auditLog);
+const mockValidateUrl = vi.mocked(validateUrl);
+const mockLoadEnv = vi.mocked(loadEnv);
+const mockValidateProjectDir = vi.mocked(validateProjectDir);
+
+// Stub fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockValidateProjectDir.mockReturnValue({ valid: true });
+  mockValidateUrl.mockResolvedValue({
+    allowed: true,
+    resolvedIp: "93.184.216.34",
+    hostname: "example.com",
+  });
+  mockLoadEnv.mockReturnValue({
+    MY_TOKEN: "tok-secret",
+    OTHER_KEY: "other-secret",
+  });
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => "OK",
+    headers: { forEach: vi.fn() },
+  });
+});
+
+describe("apiCall - audit keysAccessedCount", () => {
+  it("counts 1 key when only auth_env_key is used", async () => {
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      auth_env_key: "MY_TOKEN",
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "api_call",
+      expect.objectContaining({ keysAccessedCount: 1 })
+    );
+  });
+
+  it("counts 1 key when only a {{KEY}} template header is used", async () => {
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      headers: { "X-Api-Key": "{{MY_TOKEN}}" },
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "api_call",
+      expect.objectContaining({ keysAccessedCount: 1 })
+    );
+  });
+
+  it("counts 2 distinct keys when template and auth_env_key reference different keys", async () => {
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      headers: { "X-Api-Key": "{{OTHER_KEY}}" },
+      auth_env_key: "MY_TOKEN",
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "api_call",
+      expect.objectContaining({ keysAccessedCount: 2 })
+    );
+  });
+
+  it("counts 1 (not 2) when auth_env_key and Authorization header reference same key", async () => {
+    // Double-count bug: old code adds 1 for Authorization header + 1 for auth_env_key = 2
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      headers: { Authorization: "Bearer {{MY_TOKEN}}" },
+      auth_env_key: "MY_TOKEN",
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "api_call",
+      expect.objectContaining({ keysAccessedCount: 1 })
+    );
+  });
+
+  it("counts 0 keys when no secrets are referenced", async () => {
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "api_call",
+      expect.objectContaining({ keysAccessedCount: 0 })
+    );
+  });
+});

--- a/src/tools/api-call.ts
+++ b/src/tools/api-call.ts
@@ -96,11 +96,18 @@ export async function apiCall(
     responseHeaders[key] = sanitize(value, env);
   });
 
-  const headerCount =
-    Object.keys(headers).filter((h) => h.toLowerCase() === "authorization")
-      .length + (args.auth_env_key ? 1 : 0);
+  // Count unique env keys actually accessed: {{KEY}} templates in headers
+  // plus auth_env_key. Using a Set deduplicates when the same key appears
+  // in both (e.g. Authorization: "{{MY_TOKEN}}" + auth_env_key: "MY_TOKEN").
+  const templateKeys = Object.values(args.headers ?? {}).flatMap((v) =>
+    [...v.matchAll(/\{\{(\w+)\}\}/g)].map((m) => m[1])
+  );
+  const keysAccessed = new Set([
+    ...templateKeys,
+    ...(args.auth_env_key ? [args.auth_env_key] : []),
+  ]).size;
   auditLog("api_call", {
-    keysAccessedCount: headerCount,
+    keysAccessedCount: keysAccessed,
     status: response.ok ? "success" : "error",
   });
 


### PR DESCRIPTION
## Summary

Replaces the broken `Authorization`-header-count heuristic with a Set of unique env key names accessed during the request.

**Old logic (buggy):**
```ts
const headerCount =
  Object.keys(headers).filter(h => h.toLowerCase() === "authorization").length
  + (args.auth_env_key ? 1 : 0);
```
- Double-counts when `Authorization: {{MY_TOKEN}}` + `auth_env_key: "MY_TOKEN"` → logs `2` instead of `1`
- Ignores `{{KEY}}` templates in non-Authorization headers entirely

**New logic:**
```ts
const templateKeys = Object.values(args.headers ?? {})
  .flatMap(v => [...v.matchAll(/\{\{(\w+)\}\}/g)].map(m => m[1]));
const keysAccessed = new Set([...templateKeys, ...(args.auth_env_key ? [args.auth_env_key] : [])]).size;
```
- Extracts all `{{KEY}}` references from all header values
- Unions with `auth_env_key`
- `Set` deduplicates — same key in both sources counts once

## Test plan

- [x] `npm test` passes (39/39)
- [x] `auth_env_key` only → count 1
- [x] `{{KEY}}` template only → count 1  
- [x] Different keys in both → count 2
- [x] Same key in both → count 1 (deduped)
- [x] No secrets → count 0