### PR TITLE
Use key name in redaction tag instead of numeric index (closes #24)

### DIFF
--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { sanitize } from "./sanitize.js";
+
+describe("sanitize - redaction tag format", () => {
+  it("uses key name in redaction tag, not numeric index", () => {
+    const result = sanitize("token is sk-abc123xyz", { API_KEY: "sk-abc123xyz" });
+    expect(result).toBe("token is [REDACTED:API_KEY]");
+    expect(result).not.toMatch(/\[REDACTED:\d+\]/);
+  });
+
+  it("uses distinct key names for different secrets", () => {
+    const result = sanitize("a=secret1 b=secret2", {
+      KEY_A: "secret1",
+      KEY_B: "secret2",
+    });
+    expect(result).toContain("[REDACTED:KEY_A]");
+    expect(result).toContain("[REDACTED:KEY_B]");
+    expect(result).not.toMatch(/\[REDACTED:\d+\]/);
+  });
+
+  it("redacts base64-encoded secret with key name tag", () => {
+    const secret = "mysecretvalue";
+    const b64 = Buffer.from(secret).toString("base64");
+    const result = sanitize(`encoded: ${b64}`, { MY_SECRET: secret });
+    expect(result).toBe("encoded: [REDACTED:MY_SECRET]");
+  });
+
+  it("redacts url-encoded secret with key name tag", () => {
+    const secret = "hello world";
+    const result = sanitize(`q=${encodeURIComponent(secret)}`, { MY_KEY: secret });
+    expect(result).toBe("q=[REDACTED:MY_KEY]");
+  });
+});

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -10,10 +10,9 @@ export function sanitize(
     .sort((a, b) => b[1].length - a[1].length);
 
   let result = text;
-  let index = 1;
 
-  for (const [, value] of replacements) {
-    const tag = `[REDACTED:${index}]`;
+  for (const [key, value] of replacements) {
+    const tag = `[REDACTED:${key}]`;
 
     // Match the literal secret value
     result = result.split(value).join(tag);
@@ -29,8 +28,6 @@ export function sanitize(
     if (urlEncoded !== value) {
       result = result.split(urlEncoded).join(tag);
     }
-
-    index++;
   }
 
   // Second pass: scan for common secret patterns not in .env


### PR DESCRIPTION
## Summary

`sanitize()` was tagging redacted secrets as `[REDACTED:1]`, `[REDACTED:2]` etc. The README already documented `[REDACTED:API_KEY]` — the code was wrong.

**Before:** `"token is sk-abc123"` → `"token is [REDACTED:1]"`  
**After:** `"token is sk-abc123"` → `"token is [REDACTED:API_KEY]"`

Key names are already exposed via `get_env_keys`, so this leaks nothing new while making sanitized output significantly more debuggable.

## Changes

- `src/utils/sanitize.ts` — use `key` from the loop destructuring, remove unused `index` counter
- `src/utils/sanitize.test.ts` (new) — 4 tests: literal, multi-key, base64-encoded, URL-encoded

## Test plan

- [x] `npm test` passes (46/46)
- [x] Tag format is `[REDACTED:KEY_NAME]` for all encoding forms
- [x] Distinct keys produce distinct tags