### PR TITLE
Add GitHub Packages publishing and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@than"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --generate-notes

--- a/package.json
+++ b/package.json
@@ -1,9 +1,21 @@
 {
-  "name": "secure-api-mcp",
+  "name": "@than/secure-api-mcp",
   "version": "1.0.0",
   "description": "Secure secret proxy MCP server for Claude Code",
   "type": "module",
   "main": "dist/index.js",
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/than/secure-api-mcp.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",


### PR DESCRIPTION
## Summary

Sets up tag-triggered versioning and publishing to GitHub Packages.

## Changes

**`package.json`**
- Renamed `secure-api-mcp` → `@than/secure-api-mcp` (required scope for GitHub Packages)
- Added `publishConfig` pointing to `npm.pkg.github.com`
- Added `files` whitelist (`dist/`, `README.md`) so only built output is published
- Added `repository` field

**`.github/workflows/release.yml`**
- Triggers on `v*.*.*` tag pushes (e.g. `v1.2.0`)
- Runs full test suite before publishing
- Publishes to GitHub Packages using `GITHUB_TOKEN` (no extra secret needed)
- Creates a GitHub Release with auto-generated notes

## How to release

```bash
# Bump version in package.json, commit, then:
git tag v1.1.0
git push --tags
```

The workflow handles the rest.

## Notes

- `GITHUB_TOKEN` has `packages: write` + `contents: write` permissions scoped to this job only
- `--generate-notes` on `gh release create` pulls from merged PR titles since last tag