### PR TITLE
feat: add .my.cnf support with secret redaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-  "name": "secure-api-mcp",
+  "name": "@than/secure-api-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "secure-api-mcp",
+      "name": "@than/secure-api-mcp",
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "dotenv": "^16.4.7",
+        "ini": "^6.0.0",
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@types/ini": "^4.1.1",
         "@types/node": "^22.10.0",
         "typescript": "^5.7.0",
         "vitest": "^3.2.4"
@@ -894,6 +896,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
@@ -1744,6 +1753,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "dotenv": "^16.4.7",
+    "ini": "^6.0.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/ini": "^4.1.1",
     "@types/node": "^22.10.0",
     "typescript": "^5.7.0",
     "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@than/secure-api-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Secure secret proxy MCP server for Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { ReadMyCnfSchema, readMyCnf } from "./tools/read-mycnf.js";
 
 const server = new McpServer({
   name: "secure-api",
-  version: "1.0.0",
+  version: "1.1.0",
 });
 
 server.tool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { GetEnvKeysSchema, getEnvKeys } from "./tools/get-env-keys.js";
 import { RunWithEnvSchema, runWithEnv } from "./tools/run-with-env.js";
 import { ApiCallSchema, apiCall } from "./tools/api-call.js";
 import { SyncExampleSchema, syncExample } from "./tools/sync-example.js";
+import { ReadMyCnfSchema, readMyCnf } from "./tools/read-mycnf.js";
 
 const server = new McpServer({
   name: "secure-api",
@@ -22,7 +23,7 @@ server.tool(
 
 server.tool(
   "run_with_env",
-  "Runs a shell command with .env variables injected into the process environment. Output is sanitized — secret values are replaced with opaque [REDACTED:N] placeholders.",
+  "Runs a shell command with .env variables injected into the process environment. Output is sanitized — secret values are replaced with [REDACTED:KEY_NAME] placeholders. Set include_mycnf to also sanitize MySQL credentials from .my.cnf in command output.",
   RunWithEnvSchema.shape,
   async (args) => {
     const result = await runWithEnv(args);
@@ -46,6 +47,16 @@ server.tool(
   SyncExampleSchema.shape,
   async (args) => {
     const result = await syncExample(args);
+    return { content: [{ type: "text", text: JSON.stringify(result) }] };
+  }
+);
+
+server.tool(
+  "read_mycnf",
+  "Reads MySQL .my.cnf configuration. Returns section names and safe fields (port, database, socket) with credentials (user, password, host) redacted. Checks ~/.my.cnf and project-local .my.cnf.",
+  ReadMyCnfSchema.shape,
+  async (args) => {
+    const result = await readMyCnf(args);
     return { content: [{ type: "text", text: JSON.stringify(result) }] };
   }
 );

--- a/src/mycnf-loader.test.ts
+++ b/src/mycnf-loader.test.ts
@@ -155,6 +155,17 @@ describe("loadMyCnf - !include directive", () => {
     expect(result.sections.client?.password).toBe("from_include");
   });
 
+  it("resolves relative !include paths against parent file directory", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    // extra.cnf sits next to .my.cnf — use relative path in !include
+    writeFileSync(join(home, "extra.cnf"), "[client]\npassword=relative_secret\n");
+    writeFileSync(join(home, ".my.cnf"), "[client]\nuser=root\n!include extra.cnf\n");
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.password).toBe("relative_secret");
+  });
+
   it("detects include cycles and does not loop", async () => {
     const { loadMyCnf } = await import("./mycnf-loader.js");
     const dir = tempDir();

--- a/src/mycnf-loader.test.ts
+++ b/src/mycnf-loader.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  utimesSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "mycnf-loader-test-"));
+}
+
+const temps: string[] = [];
+function tempDir(): string {
+  const dir = makeTempDir();
+  temps.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("loadMyCnf - basic parsing", () => {
+  it("parses [client] section fields", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    writeFileSync(
+      join(home, ".my.cnf"),
+      "[client]\nuser=root\npassword=secret123\nhost=localhost\nport=3306\n"
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client).toEqual({
+      user: "root",
+      password: "secret123",
+      host: "localhost",
+      port: "3306",
+    });
+  });
+
+  it("extracts secrets keyed as section.field", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    writeFileSync(
+      join(home, ".my.cnf"),
+      "[client]\nuser=root\npassword=secret123\nhost=db.example.com\nport=3306\n"
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.secrets).toEqual({
+      "client.user": "root",
+      "client.password": "secret123",
+      "client.host": "db.example.com",
+    });
+    // port is NOT a secret field
+    expect(result.secrets).not.toHaveProperty("client.port");
+  });
+});
+
+describe("loadMyCnf - multiple sections", () => {
+  it("parses multiple sections and extracts secrets from each", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    writeFileSync(
+      join(home, ".my.cnf"),
+      "[client]\nuser=root\npassword=secret1\n\n[mysqldump]\nuser=backup\npassword=secret2\n"
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client).toEqual({
+      user: "root",
+      password: "secret1",
+    });
+    expect(result.sections.mysqldump).toEqual({
+      user: "backup",
+      password: "secret2",
+    });
+    expect(result.secrets).toEqual({
+      "client.user": "root",
+      "client.password": "secret1",
+      "mysqldump.user": "backup",
+      "mysqldump.password": "secret2",
+    });
+  });
+});
+
+describe("loadMyCnf - project-local overrides", () => {
+  it("project-local .my.cnf overrides global per-field", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    writeFileSync(
+      join(home, ".my.cnf"),
+      "[client]\nuser=global_user\npassword=global_pass\nhost=global.host\n"
+    );
+    writeFileSync(
+      join(dir, ".my.cnf"),
+      "[client]\npassword=local_pass\n"
+    );
+    const result = loadMyCnf(dir, home);
+    // user and host come from global, password overridden by local
+    expect(result.sections.client).toEqual({
+      user: "global_user",
+      password: "local_pass",
+      host: "global.host",
+    });
+    expect(result.secrets["client.password"]).toBe("local_pass");
+    expect(result.secrets["client.user"]).toBe("global_user");
+  });
+});
+
+describe("loadMyCnf - missing files", () => {
+  it("returns empty result when no .my.cnf files exist", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const result = loadMyCnf(dir, home);
+    expect(result.sections).toEqual({});
+    expect(result.secrets).toEqual({});
+  });
+
+  it("returns global only when project-local is missing", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    writeFileSync(
+      join(home, ".my.cnf"),
+      "[client]\nuser=root\n"
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client).toEqual({ user: "root" });
+    expect(result.secrets).toEqual({ "client.user": "root" });
+  });
+});
+
+describe("loadMyCnf - !include directive", () => {
+  it("follows !include and merges included file", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const includedPath = join(home, "extra.cnf");
+    writeFileSync(includedPath, "[client]\npassword=from_include\n");
+    writeFileSync(
+      join(home, ".my.cnf"),
+      `[client]\nuser=root\n!include ${includedPath}\n`
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.user).toBe("root");
+    expect(result.sections.client?.password).toBe("from_include");
+  });
+
+  it("detects include cycles and does not loop", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const fileA = join(home, ".my.cnf");
+    const fileB = join(home, "b.cnf");
+    writeFileSync(fileA, `[client]\nuser=root\n!include ${fileB}\n`);
+    writeFileSync(fileB, `[client]\npassword=secret\n!include ${fileA}\n`);
+    // Should not throw or loop forever
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.user).toBe("root");
+    expect(result.sections.client?.password).toBe("secret");
+  });
+});
+
+describe("loadMyCnf - !includedir directive", () => {
+  it("includes all .cnf files from directory", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const includeDir = join(home, "conf.d");
+    mkdirSync(includeDir);
+    writeFileSync(join(includeDir, "a.cnf"), "[client]\nuser=from_dir\n");
+    writeFileSync(join(includeDir, "b.cnf"), "[client]\npassword=dir_pass\n");
+    // non-.cnf files should be ignored
+    writeFileSync(join(includeDir, "skip.txt"), "[client]\nhost=ignored\n");
+    writeFileSync(
+      join(home, ".my.cnf"),
+      `!includedir ${includeDir}\n`
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.user).toBe("from_dir");
+    expect(result.sections.client?.password).toBe("dir_pass");
+    expect(result.sections.client?.host).toBeUndefined();
+  });
+});
+
+describe("loadMyCnf - caching", () => {
+  it("returns same reference on cache hit", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    writeFileSync(join(home, ".my.cnf"), "[client]\nuser=root\n");
+    const first = loadMyCnf(dir, home);
+    const second = loadMyCnf(dir, home);
+    expect(second).toBe(first);
+  });
+
+  it("returns fresh result when content changes but mtime is identical", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const cnfPath = join(home, ".my.cnf");
+    const fixedTime = new Date("2020-06-15T12:00:00.000Z");
+
+    writeFileSync(cnfPath, "[client]\npassword=original\n");
+    utimesSync(cnfPath, fixedTime, fixedTime);
+    const first = loadMyCnf(dir, home);
+    expect(first.secrets["client.password"]).toBe("original");
+
+    writeFileSync(cnfPath, "[client]\npassword=rotated\n");
+    utimesSync(cnfPath, fixedTime, fixedTime);
+    const second = loadMyCnf(dir, home);
+    expect(second.secrets["client.password"]).toBe("rotated");
+  });
+});

--- a/src/mycnf-loader.ts
+++ b/src/mycnf-loader.ts
@@ -1,0 +1,197 @@
+import { readFileSync, statSync, readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { parse } from "ini";
+
+/** Fields whose values are considered secrets and fed to the sanitizer. */
+const SECRET_FIELDS = new Set(["user", "password", "host"]);
+
+export interface MyCnfResult {
+  /** Map of section name to field map, e.g. { client: { user: "root", ... } } */
+  sections: Record<string, Record<string, string>>;
+  /** Flat record of secret values keyed as "section.field" */
+  secrets: Record<string, string>;
+}
+
+interface CacheEntry {
+  mtimes: Record<string, number>;
+  contentHashes: Record<string, string>;
+  result: MyCnfResult;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Read a file's content, returning null if it doesn't exist.
+ * Reads first, then stats — same TOCTOU-prevention pattern as env-loader.
+ */
+function readFile(path: string): { content: string; mtime: number } | null {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+
+  let mtime: number;
+  try {
+    mtime = statSync(path).mtimeMs;
+  } catch {
+    // File deleted between read and stat — treat content as mtime 0
+    return { content, mtime: 0 };
+  }
+
+  return { content, mtime };
+}
+
+/**
+ * Parse a single .my.cnf file, following !include / !includedir directives.
+ * `visited` tracks resolved paths for cycle detection.
+ */
+function parseFile(
+  filePath: string,
+  visited: Set<string>
+): {
+  sections: Record<string, Record<string, string>>;
+  files: Map<string, { mtime: number; contentHash: string }>;
+} {
+  const resolved = resolve(filePath);
+  const sections: Record<string, Record<string, string>> = {};
+  const files = new Map<string, { mtime: number; contentHash: string }>();
+
+  if (visited.has(resolved)) {
+    return { sections, files };
+  }
+  visited.add(resolved);
+
+  const fileData = readFile(resolved);
+  if (!fileData) {
+    return { sections, files };
+  }
+
+  const { content, mtime } = fileData;
+  const contentHash = createHash("sha256").update(content).digest("hex");
+  files.set(resolved, { mtime, contentHash });
+
+  // Extract !include and !includedir lines before INI parsing
+  // (ini package doesn't understand them)
+  const lines = content.split("\n");
+  const iniLines: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("!include ")) {
+      const target = trimmed.slice("!include ".length).trim();
+      const sub = parseFile(target, visited);
+      mergeSections(sections, sub.sections);
+      for (const [k, v] of sub.files) files.set(k, v);
+    } else if (trimmed.startsWith("!includedir ")) {
+      const dir = trimmed.slice("!includedir ".length).trim();
+      let entries: string[];
+      try {
+        entries = readdirSync(dir).filter((f) => f.endsWith(".cnf")).sort();
+      } catch {
+        entries = [];
+      }
+      for (const entry of entries) {
+        const sub = parseFile(join(dir, entry), visited);
+        mergeSections(sections, sub.sections);
+        for (const [k, v] of sub.files) files.set(k, v);
+      }
+    } else {
+      iniLines.push(line);
+    }
+  }
+
+  const parsed = parse(iniLines.join("\n"));
+  // ini.parse returns top-level keys as strings and sections as objects
+  for (const [section, value] of Object.entries(parsed)) {
+    if (typeof value === "object" && value !== null) {
+      if (!sections[section]) sections[section] = {};
+      for (const [k, v] of Object.entries(value as Record<string, string>)) {
+        sections[section][k] = String(v);
+      }
+    }
+  }
+
+  return { sections, files };
+}
+
+/** Merge `from` sections into `into`, with `from` values winning per-field. */
+function mergeSections(
+  into: Record<string, Record<string, string>>,
+  from: Record<string, Record<string, string>>
+): void {
+  for (const [section, fields] of Object.entries(from)) {
+    if (!into[section]) into[section] = {};
+    Object.assign(into[section], fields);
+  }
+}
+
+/** Extract secret fields from parsed sections. */
+function extractSecrets(
+  sections: Record<string, Record<string, string>>
+): Record<string, string> {
+  const secrets: Record<string, string> = {};
+  for (const [section, fields] of Object.entries(sections)) {
+    for (const [field, value] of Object.entries(fields)) {
+      if (SECRET_FIELDS.has(field)) {
+        secrets[`${section}.${field}`] = value;
+      }
+    }
+  }
+  return secrets;
+}
+
+/**
+ * Load and merge MySQL .my.cnf files.
+ *
+ * Resolution order (matching MySQL's own):
+ *   1. `<homeDir>/.my.cnf` (global)
+ *   2. `<projectDir>/.my.cnf` (project-local, overrides global per-field)
+ *
+ * Results are cached with mtime + SHA256 content hash.
+ */
+export function loadMyCnf(projectDir: string, homeDir: string): MyCnfResult {
+  const cacheKey = `${resolve(projectDir)}::${resolve(homeDir)}`;
+
+  // Parse both files to collect all involved files and their metadata
+  const globalVisited = new Set<string>();
+  const globalResult = parseFile(join(homeDir, ".my.cnf"), globalVisited);
+
+  const localVisited = new Set<string>();
+  const localResult = parseFile(join(projectDir, ".my.cnf"), localVisited);
+
+  // Collect all file metadata for cache comparison
+  const allFiles = new Map<string, { mtime: number; contentHash: string }>();
+  for (const [k, v] of globalResult.files) allFiles.set(k, v);
+  for (const [k, v] of localResult.files) allFiles.set(k, v);
+
+  // Check cache
+  const mtimes: Record<string, number> = {};
+  const contentHashes: Record<string, string> = {};
+  for (const [path, meta] of allFiles) {
+    mtimes[path] = meta.mtime;
+    contentHashes[path] = meta.contentHash;
+  }
+
+  const cached = cache.get(cacheKey);
+  if (
+    cached &&
+    JSON.stringify(cached.mtimes) === JSON.stringify(mtimes) &&
+    JSON.stringify(cached.contentHashes) === JSON.stringify(contentHashes)
+  ) {
+    return cached.result;
+  }
+
+  // Merge: global first, then local overrides
+  const sections: Record<string, Record<string, string>> = {};
+  mergeSections(sections, globalResult.sections);
+  mergeSections(sections, localResult.sections);
+
+  const secrets = extractSecrets(sections);
+  const result: MyCnfResult = { sections, secrets };
+
+  cache.set(cacheKey, { mtimes, contentHashes, result });
+  return result;
+}

--- a/src/mycnf-loader.ts
+++ b/src/mycnf-loader.ts
@@ -1,6 +1,6 @@
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { parse } from "ini";
 
 /** Fields whose values are considered secrets and fed to the sanitizer. */
@@ -81,12 +81,14 @@ function parseFile(
   for (const line of lines) {
     const trimmed = line.trim();
     if (trimmed.startsWith("!include ")) {
-      const target = trimmed.slice("!include ".length).trim();
+      const baseDir = dirname(resolved);
+      const target = resolve(baseDir, trimmed.slice("!include ".length).trim());
       const sub = parseFile(target, visited);
       mergeSections(sections, sub.sections);
       for (const [k, v] of sub.files) files.set(k, v);
     } else if (trimmed.startsWith("!includedir ")) {
-      const dir = trimmed.slice("!includedir ".length).trim();
+      const baseDir = dirname(resolved);
+      const dir = resolve(baseDir, trimmed.slice("!includedir ".length).trim());
       let entries: string[];
       try {
         entries = readdirSync(dir).filter((f) => f.endsWith(".cnf")).sort();

--- a/src/tools/read-mycnf.test.ts
+++ b/src/tools/read-mycnf.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock modules before importing the module under test
+vi.mock("../security/audit.js");
+vi.mock("../security/path-validator.js");
+vi.mock("../mycnf-loader.js");
+
+const { auditLog } = await import("../security/audit.js");
+const { validateProjectDir } = await import("../security/path-validator.js");
+const { loadMyCnf } = await import("../mycnf-loader.js");
+const { readMyCnf } = await import("./read-mycnf.js");
+
+const mockAuditLog = vi.mocked(auditLog);
+const mockValidateProjectDir = vi.mocked(validateProjectDir);
+const mockLoadMyCnf = vi.mocked(loadMyCnf);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockValidateProjectDir.mockReturnValue({ valid: true });
+  mockLoadMyCnf.mockReturnValue({
+    sections: {
+      client: { user: "root", password: "s3cret", host: "db.example.com", port: "3306" },
+      mysqldump: { user: "backup", password: "dumppass", single_transaction: "true" },
+    },
+    secrets: {
+      "client.user": "root",
+      "client.password": "s3cret",
+      "client.host": "db.example.com",
+      "mysqldump.user": "backup",
+      "mysqldump.password": "dumppass",
+    },
+  });
+});
+
+describe("readMyCnf", () => {
+  it("returns safe fields with secrets redacted", async () => {
+    const result = await readMyCnf({ project_dir: "/fake/project" });
+    expect(result).toEqual({
+      sections: {
+        client: {
+          user: "[REDACTED:client.user]",
+          password: "[REDACTED:client.password]",
+          host: "[REDACTED:client.host]",
+          port: "3306",
+        },
+        mysqldump: {
+          user: "[REDACTED:mysqldump.user]",
+          password: "[REDACTED:mysqldump.password]",
+          single_transaction: "true",
+        },
+      },
+    });
+  });
+
+  it("filters to a requested section", async () => {
+    const result = await readMyCnf({ project_dir: "/fake/project", section: "client" });
+    expect(result).toEqual({
+      sections: {
+        client: {
+          user: "[REDACTED:client.user]",
+          password: "[REDACTED:client.password]",
+          host: "[REDACTED:client.host]",
+          port: "3306",
+        },
+      },
+    });
+  });
+
+  it("returns error on invalid path", async () => {
+    mockValidateProjectDir.mockReturnValue({ valid: false, reason: "Path traversal blocked" });
+    const result = await readMyCnf({ project_dir: "/etc/passwd/../.." });
+    expect(result).toEqual({ error: "Path traversal blocked" });
+    expect(mockAuditLog).toHaveBeenCalledWith("read_mycnf", { status: "blocked" });
+  });
+
+  it("returns empty sections when no .my.cnf found", async () => {
+    mockLoadMyCnf.mockReturnValue({ sections: {}, secrets: {} });
+    const result = await readMyCnf({ project_dir: "/fake/project" });
+    expect(result).toEqual({ sections: {} });
+  });
+
+  it("returns empty sections when filtered section does not exist", async () => {
+    const result = await readMyCnf({ project_dir: "/fake/project", section: "nonexistent" });
+    expect(result).toEqual({ sections: {} });
+  });
+
+  it("audit logs success with keysAccessedCount", async () => {
+    await readMyCnf({ project_dir: "/fake/project" });
+    expect(mockAuditLog).toHaveBeenCalledWith("read_mycnf", {
+      keysAccessedCount: 5,
+      status: "success",
+    });
+  });
+
+  it("audit logs success with filtered keysAccessedCount", async () => {
+    await readMyCnf({ project_dir: "/fake/project", section: "client" });
+    expect(mockAuditLog).toHaveBeenCalledWith("read_mycnf", {
+      keysAccessedCount: 3,
+      status: "success",
+    });
+  });
+});

--- a/src/tools/read-mycnf.ts
+++ b/src/tools/read-mycnf.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { isAbsolute } from "node:path";
+import { homedir } from "node:os";
+import { loadMyCnf } from "../mycnf-loader.js";
+import { validateProjectDir } from "../security/path-validator.js";
+import { auditLog } from "../security/audit.js";
+
+const SECRET_FIELDS = new Set(["user", "password", "host"]);
+
+export const ReadMyCnfSchema = z.object({
+  project_dir: z
+    .string()
+    .refine((p) => isAbsolute(p), "project_dir must be an absolute path")
+    .describe("Absolute path to the project directory"),
+  section: z
+    .string()
+    .optional()
+    .describe("Filter to a specific section (e.g. 'client', 'mysqldump')"),
+});
+
+export async function readMyCnf(
+  args: z.infer<typeof ReadMyCnfSchema>
+): Promise<{ sections: Record<string, Record<string, string>> } | { error: string }> {
+  const pathCheck = validateProjectDir(args.project_dir);
+  if (!pathCheck.valid) {
+    auditLog("read_mycnf", { status: "blocked" });
+    return { error: pathCheck.reason! };
+  }
+
+  const { sections } = loadMyCnf(args.project_dir, homedir());
+
+  // Build redacted view
+  const redacted: Record<string, Record<string, string>> = {};
+  let keysAccessedCount = 0;
+
+  for (const [sectionName, fields] of Object.entries(sections)) {
+    if (args.section && sectionName !== args.section) continue;
+    redacted[sectionName] = {};
+    for (const [field, value] of Object.entries(fields)) {
+      if (SECRET_FIELDS.has(field)) {
+        redacted[sectionName][field] = `[REDACTED:${sectionName}.${field}]`;
+        keysAccessedCount++;
+      } else {
+        redacted[sectionName][field] = value;
+      }
+    }
+  }
+
+  auditLog("read_mycnf", { keysAccessedCount, status: "success" });
+  return { sections: redacted };
+}

--- a/src/tools/run-with-env.test.ts
+++ b/src/tools/run-with-env.test.ts
@@ -34,6 +34,7 @@ describe("runWithEnv with include_mycnf", () => {
     const result = await runWithEnv({
       project_dir: "/tmp",
       command: "echo supersecretpass",
+      timeout_ms: 30000,
       include_mycnf: true,
     });
 
@@ -53,6 +54,7 @@ describe("runWithEnv with include_mycnf", () => {
     const result = await runWithEnv({
       project_dir: "/tmp",
       command: "echo mysqlpass123",
+      timeout_ms: 30000,
       include_mycnf: false,
     });
 
@@ -67,6 +69,8 @@ describe("runWithEnv with include_mycnf", () => {
     const result = await runWithEnv({
       project_dir: "/tmp",
       command: "echo hello",
+      timeout_ms: 30000,
+      include_mycnf: false,
     });
 
     expect(loadMyCnf).not.toHaveBeenCalled();
@@ -84,6 +88,7 @@ describe("runWithEnv with include_mycnf", () => {
     const result = await runWithEnv({
       project_dir: "/tmp",
       command: "echo envtoken999 cnfpass888",
+      timeout_ms: 30000,
       include_mycnf: true,
     });
 

--- a/src/tools/run-with-env.test.ts
+++ b/src/tools/run-with-env.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loadEnv } from "../env-loader.js";
+import { loadMyCnf } from "../mycnf-loader.js";
+import { validateProjectDir } from "../security/path-validator.js";
+import { auditLog } from "../security/audit.js";
+
+vi.mock("../env-loader.js", () => ({ loadEnv: vi.fn() }));
+vi.mock("../mycnf-loader.js", () => ({ loadMyCnf: vi.fn() }));
+vi.mock("../security/path-validator.js", () => ({ validateProjectDir: vi.fn() }));
+vi.mock("../security/audit.js", () => ({ auditLog: vi.fn() }));
+
+const mockLoadEnv = vi.mocked(loadEnv);
+const mockLoadMyCnf = vi.mocked(loadMyCnf);
+const mockValidateProjectDir = vi.mocked(validateProjectDir);
+
+// Import after mocks are set up
+const { runWithEnv } = await import("./run-with-env.js");
+
+describe("runWithEnv with include_mycnf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateProjectDir.mockReturnValue({ valid: true });
+    mockLoadEnv.mockReturnValue({});
+    mockLoadMyCnf.mockReturnValue({ sections: {}, secrets: {} });
+  });
+
+  it("redacts mycnf secrets from stdout when include_mycnf is true", async () => {
+    mockLoadEnv.mockReturnValue({});
+    mockLoadMyCnf.mockReturnValue({
+      sections: { client: { password: "supersecretpass" } },
+      secrets: { "client.password": "supersecretpass" },
+    });
+
+    const result = await runWithEnv({
+      project_dir: "/tmp",
+      command: "echo supersecretpass",
+      include_mycnf: true,
+    });
+
+    expect(result).toHaveProperty("stdout");
+    const r = result as { stdout: string };
+    expect(r.stdout).toContain("[REDACTED:client.password]");
+    expect(r.stdout).not.toContain("supersecretpass");
+  });
+
+  it("does NOT load mycnf secrets when include_mycnf is false", async () => {
+    mockLoadEnv.mockReturnValue({});
+    mockLoadMyCnf.mockReturnValue({
+      sections: { client: { password: "mysqlpass123" } },
+      secrets: { "client.password": "mysqlpass123" },
+    });
+
+    const result = await runWithEnv({
+      project_dir: "/tmp",
+      command: "echo mysqlpass123",
+      include_mycnf: false,
+    });
+
+    expect(loadMyCnf).not.toHaveBeenCalled();
+    const r = result as { stdout: string };
+    expect(r.stdout).toContain("mysqlpass123");
+  });
+
+  it("does NOT load mycnf secrets when include_mycnf is omitted", async () => {
+    mockLoadEnv.mockReturnValue({});
+
+    const result = await runWithEnv({
+      project_dir: "/tmp",
+      command: "echo hello",
+    });
+
+    expect(loadMyCnf).not.toHaveBeenCalled();
+    const r = result as { stdout: string };
+    expect(r.stdout).toContain("hello");
+  });
+
+  it("sanitizes both .env and .my.cnf secrets when both present", async () => {
+    mockLoadEnv.mockReturnValue({ DB_TOKEN: "envtoken999" });
+    mockLoadMyCnf.mockReturnValue({
+      sections: { client: { password: "cnfpass888" } },
+      secrets: { "client.password": "cnfpass888" },
+    });
+
+    const result = await runWithEnv({
+      project_dir: "/tmp",
+      command: "echo envtoken999 cnfpass888",
+      include_mycnf: true,
+    });
+
+    const r = result as { stdout: string };
+    expect(r.stdout).toContain("[REDACTED:DB_TOKEN]");
+    expect(r.stdout).toContain("[REDACTED:client.password]");
+    expect(r.stdout).not.toContain("envtoken999");
+    expect(r.stdout).not.toContain("cnfpass888");
+  });
+});

--- a/src/tools/run-with-env.ts
+++ b/src/tools/run-with-env.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { isAbsolute } from "node:path";
 import { execFile } from "node:child_process";
 import { loadEnv } from "../env-loader.js";
+import { loadMyCnf } from "../mycnf-loader.js";
+import { homedir } from "node:os";
 import { sanitize } from "../utils/sanitize.js";
 import { validateProjectDir } from "../security/path-validator.js";
 import { auditLog } from "../security/audit.js";
@@ -21,6 +23,11 @@ export const RunWithEnvSchema = z.object({
     .optional()
     .default(30000)
     .describe("Command timeout in milliseconds"),
+  include_mycnf: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Include .my.cnf secrets in output sanitization"),
 });
 
 // Binaries that can exfiltrate data over the network
@@ -79,6 +86,13 @@ export async function runWithEnv(
 
   const env = loadEnv(args.project_dir);
 
+  // Build combined secret map for sanitization
+  let sanitizeSecrets: Record<string, string> = env;
+  if (args.include_mycnf) {
+    const mycnf = loadMyCnf(args.project_dir, homedir());
+    sanitizeSecrets = { ...env, ...mycnf.secrets };
+  }
+
   // Filter to requested keys if specified
   const injectedEnv: Record<string, string> = {};
   const keys = args.env_keys ?? Object.keys(env);
@@ -121,8 +135,8 @@ export async function runWithEnv(
         });
         resolve({
           exit_code: exitCode,
-          stdout: sanitize(stdout, env),
-          stderr: sanitize(stderr, env),
+          stdout: sanitize(stdout, sanitizeSecrets),
+          stderr: sanitize(stderr, sanitizeSecrets),
           ...(warnings.length > 0 ? { warnings } : {}),
         });
       }


### PR DESCRIPTION
## Summary

- **`mycnf-loader.ts`** — Parses `~/.my.cnf` + project-local `.my.cnf` (project overrides global per-field). Follows `!include`/`!includedir` with cycle detection. Caches with mtime + SHA256 hash.
- **`read_mycnf` MCP tool** — Returns config sections with `user`/`password`/`host` redacted as `[REDACTED:section.field]`, safe fields (port, database, socket) exposed. Optional section filter.
- **`run_with_env` extension** — New `include_mycnf` flag feeds `.my.cnf` secrets into the output sanitizer. Subprocess reads on-disk file natively (no env var injection).
- Version bump to 1.1.0

## Test plan

- [x] 12 tests for mycnf-loader (parsing, overrides, includes, caching)
- [x] 7 tests for read_mycnf tool (redaction, filtering, validation)
- [x] 4 tests for run_with_env mycnf integration (sanitization with/without flag)
- [ ] Full suite passes (134 tests)
- [ ] Build clean (our files — pre-existing api-call.test.ts type errors unrelated)
- [ ] MCP server starts without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)