### PR TITLE
Harden api_call destinations, .my.cnf includes, and request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 
 MCP server that lets Claude Code **use** secrets without **seeing** them.
 
-Claude Code [silently reads `.env` files](https://www.knostic.ai/blog/claude-loads-secrets-without-permission) and [caches them in plaintext](https://www.reddit.com/r/SideProject/comments/1rec44l/claude_code_silently_stores_your_env_api_keys_in/) in `~/.claude/file-history/`. This server injects secrets into commands and API calls at runtime, then sanitizes all output so secret values never reach Claude's context.
+Claude Code [silently reads `.env` files](https://www.knostic.ai/blog/claude-loads-secrets-without-permission) and [caches them in plaintext](https://www.reddit.com/r/SideProject/comments/1rec44l/claude_code_silently_stores_your_env_api_keys_in/) in `~/.claude/file-history/`. This server injects secrets into commands and API calls at runtime, then sanitizes output to strip secret values before they reach Claude's context.
+
+**Threat model — read this.** The strength of the guard differs by tool:
+
+- **`api_call`** has the smallest attack surface: no shell, structured output, SSRF protection, and an optional destination allowlist (see below). Sanitization reliably covers its responses.
+- **`run_with_env`** runs an arbitrary shell command. Output sanitization is **best-effort, not a hard boundary** — a command can re-encode, reverse, chunk, or otherwise transform a secret into a form the sanitizer won't recognize before printing it. Treat it as defense-in-depth.
+
+A secret can only be protected if you control where it goes. Both tools can send a secret to an external destination *by design*; restrict that with deny rules, the `api_call` allowlist, and review of `run_with_env` commands.
 
 ## Tools
 
 - **`get_env_keys(project_dir)`** — Returns key names from `.env`. No values exposed.
 - **`run_with_env(project_dir, command, env_keys?, timeout_ms?)`** — Runs a shell command with `.env` vars injected. Output is sanitized — secret values replaced with `[REDACTED:KEY_NAME]`.
-- **`api_call(project_dir, url, method?, headers?, body?, auth_env_key?)`** — HTTP request with secret injection. `auth_env_key` adds a Bearer token. Headers support `{{KEY_NAME}}` template syntax.
+- **`api_call(project_dir, url, method?, headers?, body?, auth_env_key?, timeout_ms?)`** — HTTP request with secret injection. `auth_env_key` adds a Bearer token. Headers support `{{KEY_NAME}}` template syntax. When a secret is injected, the destination host is checked against `SECURE_API_ALLOWED_HOSTS` (see below). Times out after `timeout_ms` (default 30s).
 - **`sync_env_example(project_dir)`** — Generates/updates `.env.example` from `.env`. Preserves comments and structure, strips values, uses smart placeholders.
 
 ## Setup
@@ -42,9 +49,22 @@ Run `sync_env_example` to generate or update `.env.example` from your `.env`. It
 
 Pair this with `get_env_keys` and Claude has full awareness of your project's config without any secret exposure.
 
+## Restricting where `api_call` can send secrets
+
+By default `api_call` will attach a secret to a request bound for any public host (internal/private IPs are always blocked for SSRF). To restrict this, set `SECURE_API_ALLOWED_HOSTS` to a comma-separated list of permitted hosts:
+
+```bash
+export SECURE_API_ALLOWED_HOSTS="api.stripe.com,api.github.com,*.internal.example.com"
+```
+
+- **Set** — a request that injects a secret is **blocked** unless its host matches. `*.example.com` matches any subdomain and the apex `example.com`. Matching is case-insensitive.
+- **Unset** — secrets are still sent (so existing setups keep working), but the response includes a `warnings` entry naming the destination host.
+
+Requests that inject no secret are never gated.
+
 ## How sanitization works
 
-Secret values longer than 4 characters are replaced in all output, sorted longest-first to prevent partial matches. A value like `sk-abc123xyz` in output becomes `[REDACTED:API_KEY]`.
+Secret values of 4 or more characters are replaced in all output, sorted longest-first to prevent partial matches. A value like `sk-abc123xyz` becomes `[REDACTED:API_KEY]`. The literal value, its base64 form, and its URL-encoded form are all matched, followed by a pattern pass for common token shapes (AWS, GitHub, Stripe, Slack, JWTs, private keys). Values transformed in other ways (hex, reversed, split across lines) are **not** caught — this is why `run_with_env` output is best-effort, not a guarantee.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ server.tool(
 
 server.tool(
   "run_with_env",
-  "Runs a shell command with .env variables injected into the process environment. Output is sanitized — secret values are replaced with [REDACTED:KEY_NAME] placeholders. Set include_mycnf to also sanitize MySQL credentials from .my.cnf in command output. Note: network binary detection (curl, wget, etc.) is best-effort and only catches direct invocations — indirect execution via interpreters or scripts is not detected. Output sanitization is the primary security layer.",
+  "Runs a shell command with .env variables injected into the process environment. Output is sanitized — secret values are replaced with [REDACTED:KEY_NAME] placeholders. Set include_mycnf to also sanitize MySQL credentials from .my.cnf in command output. Note: network binary detection (curl, wget, etc.) is best-effort and only catches direct invocations — indirect execution via interpreters or scripts is not detected. Output sanitization here is best-effort, not a hard boundary — a command can re-encode, reverse, or split a secret into a form the sanitizer won't catch before printing it. For sending secrets to an HTTP endpoint, prefer api_call, which has no shell surface and an optional destination allowlist.",
   RunWithEnvSchema.shape,
   async (args) => {
     const result = await runWithEnv(args);
@@ -35,7 +35,7 @@ server.tool(
   "api_call",
   `Makes an HTTP request with secrets from .env injected into headers. Use auth_env_key for Bearer tokens, or {{KEY_NAME}} syntax in headers for other auth patterns. Response body and headers are sanitized so secrets never appear in output.
 
-Prefer api_call over run_with_env+curl for simple REST calls — it's safer (no shell injection surface), returns structured {status, headers, body}, and handles secret redaction automatically. Use run_with_env when you need curl-specific features like --resolve, client certs, streaming, or non-HTTP commands.`,
+Prefer api_call over run_with_env+curl for simple REST calls — it's safer (no shell injection surface), returns structured {status, headers, body}, and handles secret redaction automatically. When a secret is injected, the destination host is checked against the SECURE_API_ALLOWED_HOSTS allowlist (if set, non-matching hosts are blocked; if unset, the call proceeds with a warning). Requests time out after timeout_ms (default 30s). Use run_with_env when you need curl-specific features like --resolve, client certs, streaming, or non-HTTP commands.`,
   ApiCallSchema.shape,
   async (args) => {
     const result = await apiCall(args);

--- a/src/mycnf-loader.test.ts
+++ b/src/mycnf-loader.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   rmSync,
   utimesSync,
+  symlinkSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -232,6 +233,42 @@ describe("loadMyCnf - include containment", () => {
     );
     const result = loadMyCnf(dir, home);
     expect(result.sections.client?.password).toBe("inproject");
+  });
+
+  it("ignores a project-local !include whose in-project target symlinks outside", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const outside = tempDir();
+    writeFileSync(join(outside, "secrets.cnf"), "[client]\nport=9999\n");
+    // innocent.cnf lives inside the project but is a symlink to the outside file.
+    symlinkSync(join(outside, "secrets.cnf"), join(dir, "innocent.cnf"));
+    writeFileSync(
+      join(dir, ".my.cnf"),
+      "[client]\nuser=root\n!include ./innocent.cnf\n"
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.user).toBe("root");
+    expect(result.sections.client?.port).toBeUndefined();
+  });
+
+  it("ignores an !includedir entry that symlinks outside the project", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const outside = tempDir();
+    writeFileSync(join(outside, "secrets.cnf"), "[client]\nport=8888\n");
+    const confd = join(dir, "conf.d");
+    mkdirSync(confd);
+    // An in-project includedir entry that is a symlink to the outside file.
+    symlinkSync(join(outside, "secrets.cnf"), join(confd, "evil.cnf"));
+    writeFileSync(
+      join(dir, ".my.cnf"),
+      "[client]\nuser=root\n!includedir ./conf.d\n"
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.user).toBe("root");
+    expect(result.sections.client?.port).toBeUndefined();
   });
 
   it("allows the global ~/.my.cnf chain to include files outside the home dir", async () => {

--- a/src/mycnf-loader.test.ts
+++ b/src/mycnf-loader.test.ts
@@ -203,6 +203,52 @@ describe("loadMyCnf - !includedir directive", () => {
   });
 });
 
+describe("loadMyCnf - include containment", () => {
+  it("ignores a project-local !include that points outside the project", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const outside = tempDir();
+    // A file outside the project that a crafted include would try to disclose.
+    writeFileSync(join(outside, "secrets.cnf"), "[client]\nport=9999\n");
+    writeFileSync(
+      join(dir, ".my.cnf"),
+      `[client]\nuser=root\n!include ${join(outside, "secrets.cnf")}\n`
+    );
+    const result = loadMyCnf(dir, home);
+    // The local section is read, but the out-of-bounds include is skipped.
+    expect(result.sections.client?.user).toBe("root");
+    expect(result.sections.client?.port).toBeUndefined();
+  });
+
+  it("still follows project-local includes that stay within the project", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    writeFileSync(join(dir, "extra.cnf"), "[client]\npassword=inproject\n");
+    writeFileSync(
+      join(dir, ".my.cnf"),
+      "[client]\nuser=root\n!include extra.cnf\n"
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.password).toBe("inproject");
+  });
+
+  it("allows the global ~/.my.cnf chain to include files outside the home dir", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    const elsewhere = tempDir();
+    writeFileSync(join(elsewhere, "system.cnf"), "[client]\npassword=systemwide\n");
+    writeFileSync(
+      join(home, ".my.cnf"),
+      `[client]\nuser=root\n!include ${join(elsewhere, "system.cnf")}\n`
+    );
+    const result = loadMyCnf(dir, home);
+    expect(result.sections.client?.password).toBe("systemwide");
+  });
+});
+
 describe("loadMyCnf - caching", () => {
   it("returns same reference on cache hit", async () => {
     const { loadMyCnf } = await import("./mycnf-loader.js");

--- a/src/mycnf-loader.test.ts
+++ b/src/mycnf-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   mkdtempSync,
   writeFileSync,
@@ -9,6 +9,13 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+// Spy on ini.parse (wrapping the real impl) so tests can assert whether a call
+// re-parsed (full path) or served the cache fast path (no parse).
+vi.mock("ini", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ini")>();
+  return { ...actual, parse: vi.fn(actual.parse) };
+});
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "mycnf-loader-test-"));
@@ -318,6 +325,38 @@ describe("loadMyCnf - caching", () => {
     const first = loadMyCnf(dir, home);
     const second = loadMyCnf(dir, home);
     expect(second).toBe(first);
+  });
+
+  // Issue #58: a contained-out symlink entry in a project !includedir is skipped
+  // at parse time, so it is never a "known file". The fast path must still serve
+  // the cache (no reparse) instead of bailing on every call just because that
+  // entry shows up in the directory listing.
+  it("serves the cache fast path when an !includedir holds a contained-out symlink entry", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const { parse } = await import("ini");
+    const mockParse = vi.mocked(parse);
+
+    const dir = tempDir();
+    const home = tempDir();
+    const outside = tempDir();
+    writeFileSync(join(outside, "secrets.cnf"), "[client]\nport=8888\n");
+    const confd = join(dir, "conf.d");
+    mkdirSync(confd);
+    writeFileSync(join(confd, "ok.cnf"), "[client]\nuser=root\n");
+    symlinkSync(join(outside, "secrets.cnf"), join(confd, "evil.cnf"));
+    writeFileSync(join(dir, ".my.cnf"), "[client]\n!includedir ./conf.d\n");
+
+    const first = loadMyCnf(dir, home); // warm the cache
+    expect(first.sections.client?.user).toBe("root");
+    expect(first.sections.client?.port).toBeUndefined(); // out-of-bounds not disclosed
+
+    mockParse.mockClear();
+    const second = loadMyCnf(dir, home);
+    // Fast path served the cache — nothing was re-parsed...
+    expect(mockParse).not.toHaveBeenCalled();
+    // ...and the same cached result is returned, still without the secret.
+    expect(second).toBe(first);
+    expect(second.sections.client?.port).toBeUndefined();
   });
 
   it("returns fresh result when content changes but mtime is identical", async () => {

--- a/src/mycnf-loader.test.ts
+++ b/src/mycnf-loader.test.ts
@@ -284,6 +284,29 @@ describe("loadMyCnf - include containment", () => {
     const result = loadMyCnf(dir, home);
     expect(result.sections.client?.password).toBe("systemwide");
   });
+
+  // Regression guard for the integration boundary between containment (this PR)
+  // and the cache fast-path (#48): containment must skip only files that EXIST
+  // out of bounds. An absent in-project include target must still be tracked as
+  // "missing" so the fast path notices it appearing later — otherwise a freshly
+  // added credentials file would be served stale.
+  it("picks up a contained in-project !include target created after the cache was populated", async () => {
+    const { loadMyCnf } = await import("./mycnf-loader.js");
+    const dir = tempDir();
+    const home = tempDir();
+    // Project-local root references later.cnf, which does not exist yet.
+    writeFileSync(
+      join(dir, ".my.cnf"),
+      "[client]\nuser=root\n!include ./later.cnf\n"
+    );
+    const first = loadMyCnf(dir, home);
+    expect(first.secrets["client.password"]).toBeUndefined();
+
+    // The in-project include target appears mid-session.
+    writeFileSync(join(dir, "later.cnf"), "[client]\npassword=appeared\n");
+    const second = loadMyCnf(dir, home);
+    expect(second.secrets["client.password"]).toBe("appeared");
+  });
 });
 
 describe("loadMyCnf - caching", () => {

--- a/src/mycnf-loader.ts
+++ b/src/mycnf-loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync, readdirSync } from "node:fs";
+import { readFileSync, statSync, readdirSync, realpathSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { dirname, join, resolve, sep } from "node:path";
 import { parse } from "ini";
@@ -52,6 +52,19 @@ function isWithin(root: string, target: string): boolean {
 }
 
 /**
+ * Canonical (symlink-resolved) path, or null if it can't be resolved (ENOENT).
+ * Used for containment checks: a lexical `resolve()` does not follow symlinks,
+ * so an in-project symlink could otherwise point at an out-of-bounds file.
+ */
+function tryRealpath(path: string): string | null {
+  try {
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Parse a single .my.cnf file, following !include / !includedir directives.
  * `visited` tracks resolved paths for cycle detection.
  *
@@ -80,6 +93,18 @@ function parseFile(
   }
   visited.add(resolved);
 
+  // Containment for the untrusted project-local chain: the *real* (symlink-
+  // resolved) path of every file we actually read must stay within `containTo`.
+  // Enforcing here — at the read point — covers !include targets, !includedir
+  // entries, and a symlinked .my.cnf alike. A purely lexical check on the
+  // directive target would let an in-project symlink escape the project.
+  if (containTo) {
+    const real = tryRealpath(resolved);
+    if (!real || !isWithin(containTo, real)) {
+      return { sections, files };
+    }
+  }
+
   const fileData = readFile(resolved);
   if (!fileData) {
     return { sections, files };
@@ -99,14 +124,20 @@ function parseFile(
     if (trimmed.startsWith("!include ")) {
       const baseDir = dirname(resolved);
       const target = resolve(baseDir, trimmed.slice("!include ".length).trim());
-      if (containTo && !isWithin(containTo, target)) continue; // out-of-bounds include
+      // Containment is enforced authoritatively at parseFile's read point
+      // (canonical-path check), which also catches symlinked targets.
       const sub = parseFile(target, visited, containTo);
       mergeSections(sections, sub.sections);
       for (const [k, v] of sub.files) files.set(k, v);
     } else if (trimmed.startsWith("!includedir ")) {
       const baseDir = dirname(resolved);
       const dir = resolve(baseDir, trimmed.slice("!includedir ".length).trim());
-      if (containTo && !isWithin(containTo, dir)) continue; // out-of-bounds include
+      // Skip listing a directory whose real path is out of bounds; each entry
+      // is still re-checked by canonical path when parseFile reads it.
+      if (containTo) {
+        const realDir = tryRealpath(dir);
+        if (!realDir || !isWithin(containTo, realDir)) continue;
+      }
       let entries: string[];
       try {
         entries = readdirSync(dir).filter((f) => f.endsWith(".cnf")).sort();
@@ -180,12 +211,14 @@ export function loadMyCnf(projectDir: string, homeDir: string): MyCnfResult {
   const globalResult = parseFile(join(homeDir, ".my.cnf"), globalVisited);
 
   // Contain the project-local chain to the project directory: its .my.cnf may
-  // be untrusted, so its includes must not reach outside the project.
+  // be untrusted, so its includes must not reach outside the project. Contain
+  // against the canonical project path so a symlinked project root (e.g. macOS
+  // /tmp -> /private/tmp) doesn't reject legitimate in-project includes.
   const localVisited = new Set<string>();
   const localResult = parseFile(
     join(projectDir, ".my.cnf"),
     localVisited,
-    resolve(projectDir)
+    tryRealpath(projectDir) ?? resolve(projectDir)
   );
 
   // Collect all file metadata for cache comparison

--- a/src/mycnf-loader.ts
+++ b/src/mycnf-loader.ts
@@ -1,6 +1,6 @@
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { parse } from "ini";
 
 /** Fields whose values are considered secrets and fed to the sanitizer. */
@@ -44,13 +44,29 @@ function readFile(path: string): { content: string; mtime: number } | null {
   return { content, mtime };
 }
 
+/** True if `target` resolves to `root` or a path nested under it. */
+function isWithin(root: string, target: string): boolean {
+  const r = resolve(root);
+  const t = resolve(target);
+  return t === r || t.startsWith(r + sep);
+}
+
 /**
  * Parse a single .my.cnf file, following !include / !includedir directives.
  * `visited` tracks resolved paths for cycle detection.
+ *
+ * `containTo`, when set, restricts !include / !includedir targets to paths
+ * within that directory. This is applied to the project-local chain, whose
+ * .my.cnf may be attacker-supplied (e.g. committed to a repo), to stop a
+ * crafted include from pulling in arbitrary files elsewhere on disk —
+ * read_mycnf returns non-secret fields verbatim, so an unbounded include
+ * would be a file-disclosure primitive. The trusted global (~/.my.cnf) chain
+ * is parsed with no containment so legitimate /etc includes still work.
  */
 function parseFile(
   filePath: string,
-  visited: Set<string>
+  visited: Set<string>,
+  containTo?: string
 ): {
   sections: Record<string, Record<string, string>>;
   files: Map<string, { mtime: number; contentHash: string }>;
@@ -83,12 +99,14 @@ function parseFile(
     if (trimmed.startsWith("!include ")) {
       const baseDir = dirname(resolved);
       const target = resolve(baseDir, trimmed.slice("!include ".length).trim());
-      const sub = parseFile(target, visited);
+      if (containTo && !isWithin(containTo, target)) continue; // out-of-bounds include
+      const sub = parseFile(target, visited, containTo);
       mergeSections(sections, sub.sections);
       for (const [k, v] of sub.files) files.set(k, v);
     } else if (trimmed.startsWith("!includedir ")) {
       const baseDir = dirname(resolved);
       const dir = resolve(baseDir, trimmed.slice("!includedir ".length).trim());
+      if (containTo && !isWithin(containTo, dir)) continue; // out-of-bounds include
       let entries: string[];
       try {
         entries = readdirSync(dir).filter((f) => f.endsWith(".cnf")).sort();
@@ -96,7 +114,7 @@ function parseFile(
         entries = [];
       }
       for (const entry of entries) {
-        const sub = parseFile(join(dir, entry), visited);
+        const sub = parseFile(join(dir, entry), visited, containTo);
         mergeSections(sections, sub.sections);
         for (const [k, v] of sub.files) files.set(k, v);
       }
@@ -161,8 +179,14 @@ export function loadMyCnf(projectDir: string, homeDir: string): MyCnfResult {
   const globalVisited = new Set<string>();
   const globalResult = parseFile(join(homeDir, ".my.cnf"), globalVisited);
 
+  // Contain the project-local chain to the project directory: its .my.cnf may
+  // be untrusted, so its includes must not reach outside the project.
   const localVisited = new Set<string>();
-  const localResult = parseFile(join(projectDir, ".my.cnf"), localVisited);
+  const localResult = parseFile(
+    join(projectDir, ".my.cnf"),
+    localVisited,
+    resolve(projectDir)
+  );
 
   // Collect all file metadata for cache comparison
   const allFiles = new Map<string, { mtime: number; contentHash: string }>();

--- a/src/mycnf-loader.ts
+++ b/src/mycnf-loader.ts
@@ -18,8 +18,13 @@ interface CacheEntry {
   filePaths: string[];
   mtimes: Record<string, number>;
   contentHashes: Record<string, string>;
-  /** Directories referenced by `!includedir`, re-listed on the fast path to detect added files */
-  includeDirs: string[];
+  /**
+   * `!includedir` path -> sorted `.cnf` listing at parse time. Re-listed on the
+   * fast path to detect added/removed entries (robust even if the dir mtime is
+   * preserved). Comparing the raw listing — not just parsed files — means a
+   * containment-skipped entry that persists doesn't perpetually invalidate.
+   */
+  dirListings: Record<string, string[]>;
   /** Referenced paths (roots / !include targets) that were absent — watched for appearance */
   missingPaths: string[];
   result: MyCnfResult;
@@ -98,19 +103,20 @@ function parseFile(
 ): {
   sections: Record<string, Record<string, string>>;
   files: Map<string, { mtime: number; contentHash: string }>;
-  dirs: Set<string>;
+  dirListings: Map<string, string[]>;
   missing: Set<string>;
 } {
   const resolved = resolve(filePath);
   const sections: Record<string, Record<string, string>> = {};
   const files = new Map<string, { mtime: number; contentHash: string }>();
-  const dirs = new Set<string>();
+  // `!includedir` path -> its sorted .cnf listing, for fast-path membership checks.
+  const dirListings = new Map<string, string[]>();
   // Paths that were referenced (roots / !include targets) but did not exist.
   // Tracked so the cache fast path can detect one appearing later.
   const missing = new Set<string>();
 
   if (visited.has(resolved)) {
-    return { sections, files, dirs, missing };
+    return { sections, files, dirListings, missing };
   }
   visited.add(resolved);
 
@@ -125,14 +131,14 @@ function parseFile(
   if (containTo) {
     const real = tryRealpath(resolved);
     if (real && !isWithin(containTo, real)) {
-      return { sections, files, dirs, missing };
+      return { sections, files, dirListings, missing };
     }
   }
 
   const fileData = readFile(resolved);
   if (!fileData) {
     missing.add(resolved);
-    return { sections, files, dirs, missing };
+    return { sections, files, dirListings, missing };
   }
 
   const { content, mtime } = fileData;
@@ -154,7 +160,7 @@ function parseFile(
       const sub = parseFile(target, visited, containTo);
       mergeSections(sections, sub.sections);
       for (const [k, v] of sub.files) files.set(k, v);
-      for (const d of sub.dirs) dirs.add(d);
+      for (const [k, v] of sub.dirListings) dirListings.set(k, v);
       for (const m of sub.missing) missing.add(m);
     } else if (trimmed.startsWith("!includedir ")) {
       const baseDir = dirname(resolved);
@@ -166,20 +172,22 @@ function parseFile(
         const realDir = tryRealpath(dir);
         if (realDir && !isWithin(containTo, realDir)) continue;
       }
-      // Track in-bounds includedirs so the fast path can re-list them and
-      // detect a newly dropped .cnf even if the dir mtime is preserved.
-      dirs.add(dir);
       let entries: string[];
       try {
         entries = readdirSync(dir).filter((f) => f.endsWith(".cnf")).sort();
       } catch {
         entries = [];
       }
+      // Snapshot the raw listing so the fast path can spot added/removed entries
+      // even if the dir mtime is preserved. Recording all entries (not just the
+      // ones that parse cleanly) keeps a containment-skipped entry from forcing a
+      // reparse on every call.
+      dirListings.set(dir, entries);
       for (const entry of entries) {
         const sub = parseFile(join(dir, entry), visited, containTo);
         mergeSections(sections, sub.sections);
         for (const [k, v] of sub.files) files.set(k, v);
-        for (const d of sub.dirs) dirs.add(d);
+        for (const [k, v] of sub.dirListings) dirListings.set(k, v);
         for (const m of sub.missing) missing.add(m);
       }
     } else {
@@ -198,7 +206,7 @@ function parseFile(
     }
   }
 
-  return { sections, files, dirs, missing };
+  return { sections, files, dirListings, missing };
 }
 
 /** Merge `from` sections into `into`, with `from` values winning per-field. */
@@ -250,22 +258,22 @@ export function loadMyCnf(projectDir: string, homeDir: string): MyCnfResult {
   // is robust even if the directory's own mtime was preserved.
   const cached = cache.get(cacheKey);
   if (cached) {
-    const knownFiles = new Set(cached.filePaths);
-
     const appeared = cached.missingPaths.some((p) => tryMtime(p) !== 0);
     const mtimesMatch = cached.filePaths.every(
       (p) => tryMtime(p) === cached.mtimes[p]
     );
     const membershipUnchanged =
       !appeared &&
-      cached.includeDirs.every((dir) => {
+      Object.entries(cached.dirListings).every(([dir, prev]) => {
         let entries: string[];
         try {
-          entries = readdirSync(dir).filter((f) => f.endsWith(".cnf"));
+          entries = readdirSync(dir).filter((f) => f.endsWith(".cnf")).sort();
         } catch {
           entries = [];
         }
-        return entries.every((e) => knownFiles.has(resolve(join(dir, e))));
+        return (
+          entries.length === prev.length && entries.every((e, i) => e === prev[i])
+        );
       });
 
     if (mtimesMatch && membershipUnchanged) {
@@ -319,11 +327,11 @@ export function loadMyCnf(projectDir: string, homeDir: string): MyCnfResult {
     contentHashes[path] = meta.contentHash;
   }
 
-  // !includedir directories (re-listed on the fast path) and referenced-but-absent
+  // !includedir listings (re-listed on the fast path) and referenced-but-absent
   // paths (watched for appearance) — both needed to detect file-set changes.
-  const includeDirs = [
-    ...new Set([...globalResult.dirs, ...localResult.dirs]),
-  ].sort();
+  const dirListings: Record<string, string[]> = {};
+  for (const [k, v] of globalResult.dirListings) dirListings[k] = v;
+  for (const [k, v] of localResult.dirListings) dirListings[k] = v;
   const missingPaths = [
     ...new Set([...globalResult.missing, ...localResult.missing]),
   ].sort();
@@ -340,7 +348,7 @@ export function loadMyCnf(projectDir: string, homeDir: string): MyCnfResult {
       filePaths,
       mtimes,
       contentHashes,
-      includeDirs,
+      dirListings,
       missingPaths,
       result: cached.result,
     });
@@ -359,7 +367,7 @@ export function loadMyCnf(projectDir: string, homeDir: string): MyCnfResult {
     filePaths,
     mtimes,
     contentHashes,
-    includeDirs,
+    dirListings,
     missingPaths,
     result,
   });

--- a/src/security/host-allowlist.test.ts
+++ b/src/security/host-allowlist.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { getHostPolicy } from "./host-allowlist.js";
+
+describe("getHostPolicy - unenforced (no allowlist)", () => {
+  it("is not enforced and allows everything when var is unset", () => {
+    const policy = getHostPolicy({} as NodeJS.ProcessEnv);
+    expect(policy.enforced).toBe(false);
+    expect(policy.allows("anything.example.com")).toBe(true);
+  });
+
+  it("is not enforced when var is empty or whitespace", () => {
+    expect(getHostPolicy({ SECURE_API_ALLOWED_HOSTS: "" } as NodeJS.ProcessEnv).enforced).toBe(false);
+    expect(getHostPolicy({ SECURE_API_ALLOWED_HOSTS: "  ,  " } as NodeJS.ProcessEnv).enforced).toBe(false);
+  });
+});
+
+describe("getHostPolicy - enforced (allowlist set)", () => {
+  it("allows exact host matches and blocks others", () => {
+    const policy = getHostPolicy({
+      SECURE_API_ALLOWED_HOSTS: "api.stripe.com, api.github.com",
+    } as NodeJS.ProcessEnv);
+    expect(policy.enforced).toBe(true);
+    expect(policy.allows("api.stripe.com")).toBe(true);
+    expect(policy.allows("api.github.com")).toBe(true);
+    expect(policy.allows("evil.example.com")).toBe(false);
+  });
+
+  it("matches case-insensitively", () => {
+    const policy = getHostPolicy({
+      SECURE_API_ALLOWED_HOSTS: "Api.Stripe.Com",
+    } as NodeJS.ProcessEnv);
+    expect(policy.allows("api.stripe.com")).toBe(true);
+  });
+
+  it("supports leading-wildcard subdomain matches, including the apex", () => {
+    const policy = getHostPolicy({
+      SECURE_API_ALLOWED_HOSTS: "*.example.com",
+    } as NodeJS.ProcessEnv);
+    expect(policy.allows("a.example.com")).toBe(true);
+    expect(policy.allows("a.b.example.com")).toBe(true);
+    expect(policy.allows("example.com")).toBe(true);
+    expect(policy.allows("notexample.com")).toBe(false);
+    expect(policy.allows("example.com.evil.com")).toBe(false);
+  });
+
+  it("strips brackets from IPv6 literal hosts before matching", () => {
+    const policy = getHostPolicy({
+      SECURE_API_ALLOWED_HOSTS: "::1",
+    } as NodeJS.ProcessEnv);
+    expect(policy.allows("[::1]")).toBe(true);
+  });
+});

--- a/src/security/host-allowlist.ts
+++ b/src/security/host-allowlist.ts
@@ -1,0 +1,64 @@
+/**
+ * Destination host allowlist for api_call.
+ *
+ * A secret is only safe to attach to an outbound request if we know where it's
+ * going. When SECURE_API_ALLOWED_HOSTS is set (comma-separated host patterns),
+ * secrets are only attached to requests whose host matches — anything else is
+ * blocked. When the variable is unset, enforcement is off: the secret still
+ * goes through (so existing setups keep working), but callers get a warning so
+ * exfiltration to an unexpected host is at least visible.
+ *
+ * Patterns support exact hostnames ("api.stripe.com") and leading-wildcard
+ * subdomain matches ("*.example.com" — matches "a.example.com" and the apex
+ * "example.com"). Matching is case-insensitive.
+ */
+
+export interface HostPolicy {
+  /** True when an allowlist is configured, i.e. hard enforcement is active. */
+  enforced: boolean;
+  /** Returns true if `host` is permitted to receive secrets. */
+  allows(host: string): boolean;
+}
+
+function parsePatterns(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((p) => p.trim().toLowerCase())
+    .filter((p) => p.length > 0);
+}
+
+function matchPattern(pattern: string, host: string): boolean {
+  if (pattern.startsWith("*.")) {
+    const base = pattern.slice(2);
+    return host === base || host.endsWith("." + base);
+  }
+  return host === pattern;
+}
+
+/** Strip surrounding brackets from an IPv6 literal hostname. */
+function bareHost(host: string): string {
+  if (host.startsWith("[") && host.endsWith("]")) {
+    return host.slice(1, -1);
+  }
+  return host;
+}
+
+export function getHostPolicy(
+  env: NodeJS.ProcessEnv = process.env
+): HostPolicy {
+  const raw = env.SECURE_API_ALLOWED_HOSTS;
+  const patterns = raw ? parsePatterns(raw) : [];
+
+  if (patterns.length === 0) {
+    // Unset or empty — enforcement off, everything allowed.
+    return { enforced: false, allows: () => true };
+  }
+
+  return {
+    enforced: true,
+    allows: (host: string) => {
+      const h = bareHost(host).toLowerCase();
+      return patterns.some((p) => matchPattern(p, h));
+    },
+  };
+}

--- a/src/tools/api-call.test.ts
+++ b/src/tools/api-call.test.ts
@@ -145,15 +145,25 @@ describe("apiCall - fetch error handling", () => {
   });
 
   it("reports a timeout when fetch aborts", async () => {
-    const abortErr = new Error("aborted");
-    abortErr.name = "AbortError";
-    mockFetch.mockRejectedValue(abortErr);
+    // Reject with the *real* abort reason the runtime sets when apiCall's
+    // internal AbortController fires (a DOMException), not a hand-built Error.
+    // This verifies the friendly-message branch (instanceof Error && name ===
+    // "AbortError") actually holds for a genuine abort on the Node target — a
+    // synthetic Error would mask a regression if that ever stopped being true.
+    mockFetch.mockImplementation(
+      (_url: string, opts: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener("abort", () =>
+            reject(opts.signal.reason)
+          );
+        })
+    );
     const result = await apiCall({
       project_dir: "/fake/project",
       url: "https://example.com",
-      timeout_ms: 5000,
+      timeout_ms: 1,
     });
-    expect(result.body).toBe("Fetch failed: Request timed out after 5000ms");
+    expect(result.body).toBe("Fetch failed: Request timed out after 1ms");
   });
 
   it("passes an abort signal to fetch", async () => {

--- a/src/tools/api-call.test.ts
+++ b/src/tools/api-call.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock modules before importing the module under test
 vi.mock("../security/audit.js");
@@ -142,5 +142,82 @@ describe("apiCall - fetch error handling", () => {
       "https://example.com/api/data",
       expect.objectContaining({ method: "GET", dispatcher: expect.anything() })
     );
+  });
+
+  it("reports a timeout when fetch aborts", async () => {
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+    mockFetch.mockRejectedValue(abortErr);
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      timeout_ms: 5000,
+    });
+    expect(result.body).toBe("Fetch failed: Request timed out after 5000ms");
+  });
+
+  it("passes an abort signal to fetch", async () => {
+    await apiCall({ project_dir: "/fake/project", url: "https://example.com" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({ signal: expect.anything() })
+    );
+  });
+});
+
+describe("apiCall - destination allowlist", () => {
+  const ORIGINAL = process.env.SECURE_API_ALLOWED_HOSTS;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.SECURE_API_ALLOWED_HOSTS;
+    else process.env.SECURE_API_ALLOWED_HOSTS = ORIGINAL;
+  });
+
+  it("warns but still sends when no allowlist is configured", async () => {
+    delete process.env.SECURE_API_ALLOWED_HOSTS;
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      auth_env_key: "MY_TOKEN",
+    });
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result.warnings?.[0]).toContain("example.com");
+  });
+
+  it("blocks and does not send when host is off the allowlist", async () => {
+    process.env.SECURE_API_ALLOWED_HOSTS = "api.allowed.com";
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      auth_env_key: "MY_TOKEN",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.status).toBe(0);
+    expect(result.body).toContain("Request blocked");
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      "api_call",
+      expect.objectContaining({ status: "blocked" })
+    );
+  });
+
+  it("sends without warning when host is on the allowlist", async () => {
+    process.env.SECURE_API_ALLOWED_HOSTS = "example.com";
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      auth_env_key: "MY_TOKEN",
+    });
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it("does not gate requests that carry no secret", async () => {
+    process.env.SECURE_API_ALLOWED_HOSTS = "api.allowed.com";
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result.body).toBe("OK");
   });
 });

--- a/src/tools/api-call.test.ts
+++ b/src/tools/api-call.test.ts
@@ -230,4 +230,20 @@ describe("apiCall - destination allowlist", () => {
     expect(mockFetch).toHaveBeenCalled();
     expect(result.body).toBe("OK");
   });
+
+  it("treats inherited Object.prototype names as non-keys (no false secret injection)", async () => {
+    // {{constructor}} is not a real env key; `in` would match Object.prototype
+    // and wrongly classify this as secret-bearing, gating it against the allowlist.
+    process.env.SECURE_API_ALLOWED_HOSTS = "api.allowed.com";
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      headers: { "X-Test": "{{constructor}}" },
+    });
+    // Not gated/blocked — the request carries no real secret...
+    expect(mockFetch).toHaveBeenCalled();
+    // ...and the template is left untouched (no stringified function leaked in).
+    const sentHeaders = mockFetch.mock.calls[0][1].headers;
+    expect(sentHeaders["X-Test"]).toBe("{{constructor}}");
+  });
 });

--- a/src/tools/api-call.ts
+++ b/src/tools/api-call.ts
@@ -5,6 +5,7 @@ import { loadEnv } from "../env-loader.js";
 import { sanitize } from "../utils/sanitize.js";
 import { validateUrl } from "../security/url-validator.js";
 import { validateProjectDir } from "../security/path-validator.js";
+import { getHostPolicy } from "../security/host-allowlist.js";
 import { auditLog } from "../security/audit.js";
 
 export const ApiCallSchema = z.object({
@@ -26,24 +27,47 @@ export const ApiCallSchema = z.object({
     .string()
     .optional()
     .describe("Env key to use as Bearer token"),
+  timeout_ms: z
+    .number()
+    .optional()
+    .default(30000)
+    .describe("Request timeout in milliseconds"),
 });
+
+interface InterpolationResult {
+  headers: Record<string, string>;
+  /** Env keys whose value was actually substituted into a header. */
+  injectedKeys: string[];
+}
 
 function interpolateHeaders(
   headers: Record<string, string>,
   env: Record<string, string>
-): Record<string, string> {
+): InterpolationResult {
   const result: Record<string, string> = {};
+  const injectedKeys: string[] = [];
   for (const [key, value] of Object.entries(headers)) {
     result[key] = value.replace(/\{\{(\w+)\}\}/g, (_, envKey: string) => {
-      return env[envKey] ?? `{{${envKey}}}`;
+      if (envKey in env) {
+        injectedKeys.push(envKey);
+        return env[envKey];
+      }
+      return `{{${envKey}}}`;
     });
   }
-  return result;
+  return { headers: result, injectedKeys };
+}
+
+interface ApiCallResult {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  warnings?: string[];
 }
 
 export async function apiCall(
   args: z.infer<typeof ApiCallSchema>
-): Promise<{ status: number; headers: Record<string, string>; body: string }> {
+): Promise<ApiCallResult> {
   // Path traversal protection
   const pathCheck = validateProjectDir(args.project_dir);
   if (!pathCheck.valid) {
@@ -64,22 +88,54 @@ export async function apiCall(
 
   const env = loadEnv(args.project_dir);
 
-  const headers: Record<string, string> = args.headers
+  const interpolated = args.headers
     ? interpolateHeaders(args.headers, env)
-    : {};
+    : { headers: {}, injectedKeys: [] };
+  const headers: Record<string, string> = interpolated.headers;
+  const injectedKeys = new Set(interpolated.injectedKeys);
 
   if (args.auth_env_key && env[args.auth_env_key]) {
     headers["Authorization"] = `Bearer ${env[args.auth_env_key]}`;
+    injectedKeys.add(args.auth_env_key);
+  }
+
+  // Destination control: a secret is only safe to send somewhere we trust.
+  // If any secret was actually injected, check the host against the allowlist.
+  // Enforced (SECURE_API_ALLOWED_HOSTS set): block non-matching hosts.
+  // Unenforced (unset): allow but warn so an unexpected destination is visible.
+  const warnings: string[] = [];
+  if (injectedKeys.size > 0) {
+    const policy = getHostPolicy();
+    const host = new URL(args.url).hostname;
+    if (policy.enforced) {
+      if (!policy.allows(host)) {
+        auditLog("api_call", { status: "blocked" });
+        return {
+          status: 0,
+          headers: {},
+          body: `Request blocked: host '${host}' is not in SECURE_API_ALLOWED_HOSTS — refusing to send secrets to an unapproved destination`,
+        };
+      }
+    } else {
+      // No allowlist configured — secret still goes out, but make it visible.
+      warnings.push(
+        `Secret(s) sent to '${host}'. Set SECURE_API_ALLOWED_HOSTS to restrict where secrets may be sent.`
+      );
+    }
   }
 
   // Pin the resolved IP at the socket layer to close the DNS rebinding
   // TOCTOU window. The URL keeps the original hostname (preserving TLS
   // SNI and cert validation), but undici's lookup callback returns the
   // IP that validateUrl already checked instead of re-resolving DNS.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), args.timeout_ms);
+
   const fetchOptions: Record<string, unknown> = {
     method: args.method,
     headers,
     body: args.body,
+    signal: controller.signal,
   };
   if (urlCheck.resolvedIp) {
     const pinnedIp = urlCheck.resolvedIp;
@@ -97,8 +153,20 @@ export async function apiCall(
     response = await fetch(args.url, fetchOptions);
   } catch (err) {
     auditLog("api_call", { status: "error" });
-    const message = err instanceof Error ? err.message : String(err);
-    return { status: 0, headers: {}, body: sanitize(`Fetch failed: ${message}`, env) };
+    const message =
+      err instanceof Error && err.name === "AbortError"
+        ? `Request timed out after ${args.timeout_ms}ms`
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return {
+      status: 0,
+      headers: {},
+      body: sanitize(`Fetch failed: ${message}`, env),
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
+  } finally {
+    clearTimeout(timer);
   }
 
   const bodyText = await response.text();
@@ -107,18 +175,12 @@ export async function apiCall(
     responseHeaders[key] = sanitize(value, env);
   });
 
-  // Count unique env keys actually accessed: {{KEY}} templates in headers
-  // plus auth_env_key. Using a Set deduplicates when the same key appears
-  // in both (e.g. Authorization: "{{MY_TOKEN}}" + auth_env_key: "MY_TOKEN").
-  const templateKeys = Object.values(args.headers ?? {}).flatMap((v) =>
-    [...v.matchAll(/\{\{(\w+)\}\}/g)].map((m) => m[1])
-  );
-  const keysAccessed = new Set([
-    ...templateKeys,
-    ...(args.auth_env_key ? [args.auth_env_key] : []),
-  ]).size;
+  // injectedKeys already holds the unique env keys whose values were actually
+  // substituted — {{KEY}} templates that resolved plus auth_env_key — so it
+  // deduplicates when the same key appears in both and excludes templates that
+  // referenced a missing key.
   auditLog("api_call", {
-    keysAccessedCount: keysAccessed,
+    keysAccessedCount: injectedKeys.size,
     status: response.ok ? "success" : "error",
   });
 
@@ -126,5 +188,6 @@ export async function apiCall(
     status: response.status,
     headers: responseHeaders,
     body: sanitize(bodyText, env),
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
 }

--- a/src/tools/api-call.ts
+++ b/src/tools/api-call.ts
@@ -48,7 +48,10 @@ function interpolateHeaders(
   const injectedKeys: string[] = [];
   for (const [key, value] of Object.entries(headers)) {
     result[key] = value.replace(/\{\{(\w+)\}\}/g, (_, envKey: string) => {
-      if (envKey in env) {
+      // Object.hasOwn, not `in`: `in` matches inherited Object.prototype names
+      // (constructor, toString, __proto__, …), which would stringify a function
+      // into the header and falsely flag the request as secret-bearing.
+      if (Object.hasOwn(env, envKey)) {
         injectedKeys.push(envKey);
         return env[envKey];
       }


### PR DESCRIPTION
Security hardening from a full audit of the codebase. Three code fixes plus documentation accuracy.

## api_call destination allowlist (new: `SECURE_API_ALLOWED_HOSTS`)

`api_call` injects a secret (Bearer token or `{{KEY}}` header) and sends it to whatever URL the caller chose. The only destination check was the SSRF guard, which blocks *private* IPs — nothing restricted public hosts, so a prompt-injected agent could send any secret to any attacker-controlled server, with no warning. Response sanitization can't help; the secret leaves in the *request*.

Now, when a secret is actually injected, the destination host is checked against `SECURE_API_ALLOWED_HOSTS` (comma-separated, case-insensitive, `*.example.com` matches subdomains + apex):

- **Set** — secret-bearing requests to non-matching hosts are blocked before fetch, and audit-logged as `blocked`.
- **Unset** — non-breaking fallback: the call proceeds, but the response carries a `warnings` entry naming the destination.
- Requests that inject no secret are never gated.

New module `src/security/host-allowlist.ts` with tests.

## api_call request timeout

`run_with_env` had `timeout_ms`, but `api_call`'s fetch had no timeout — a hung endpoint stalled the MCP server indefinitely. Added `timeout_ms` (default 30s) via `AbortController`, with a clear `Request timed out after Nms` error.

## .my.cnf include containment

Project-local `.my.cnf` `!include` / `!includedir` directives followed any absolute path. Since `read_mycnf` returns non-`user`/`password`/`host` fields verbatim, a crafted project-local config (e.g. committed to a cloned repo) was an arbitrary-file-disclosure primitive for INI-shaped files. Project-local includes are now contained to the project directory; the trusted global `~/.my.cnf` chain is unrestricted so legitimate `/etc/mysql` includes keep working.

## Documentation accuracy

The README claimed secret values "never reach Claude's context." That's enforceable for `api_call` but not for `run_with_env`, where a shell command can re-encode/reverse/split a secret before printing it — sanitization there is best-effort defense-in-depth. README and tool descriptions now state the threat model per tool, document the allowlist, and fix the redaction-length wording (≥4 chars, code says `> 3`).

## Testing

- 152 tests pass (137 existing + 15 new covering allowlist matching, gating/warn/block paths, timeout, and include containment).
- `npm run build` clean.

https://claude.ai/code/session_0112QGA9ZvdadMcJiVBXffCP

---
_Generated by [Claude Code](https://claude.ai/code/session_0112QGA9ZvdadMcJiVBXffCP)_