### PR TITLE
fix: tie @claude trust gate to the actor per event (security)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,24 +12,32 @@ on:
 
 jobs:
   claude:
+    # Only trigger for trusted users (repo owner / org members / collaborators).
+    # The trust check is tied PER EVENT to the author_association of the object
+    # that carries the "@claude" mention (i.e. the actual actor) — it must NOT be
+    # OR'd across unrelated objects, or an untrusted commenter on an issue/PR that
+    # a trusted member opened would pass the gate.
     if: |
-      (
-        github.event.sender.login == github.repository_owner ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.issue.author_association == 'OWNER' ||
-        github.event.issue.author_association == 'MEMBER' ||
-        github.event.issue.author_association == 'COLLABORATOR' ||
-        github.event.review.author_association == 'OWNER' ||
-        github.event.review.author_association == 'MEMBER' ||
-        github.event.review.author_association == 'COLLABORATOR'
-      ) && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'MEMBER' ||
+         github.event.review.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Security fix
The `claude.yml` gate OR'd `author_association` across `comment`/`issue`/`review` objects. On an `issue_comment` event, `github.event.issue.author_association` reflects whoever **opened** the issue/PR — so an **untrusted commenter** writing `@claude` on an issue opened by a trusted member **passed the gate**.

Fix: each event branch now checks the `author_association` of the object that actually carries the mention (comment for issue_comment / review_comment, review for pull_request_review, issue for issues). Only the real actor is trusted.

Same fix is going to the template (Broomfitters/house#305) and munksapp/munks#137. Pure `if:`-expression logic; YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)