### PR TITLE
Bound timeout_ms to a positive integer in api_call and run_with_env

### DIFF
--- a/src/tools/api-call.test.ts
+++ b/src/tools/api-call.test.ts
@@ -10,7 +10,7 @@ const { auditLog } = await import("../security/audit.js");
 const { validateUrl } = await import("../security/url-validator.js");
 const { loadEnv } = await import("../env-loader.js");
 const { validateProjectDir } = await import("../security/path-validator.js");
-const { apiCall } = await import("./api-call.js");
+const { apiCall, ApiCallSchema } = await import("./api-call.js");
 
 const mockAuditLog = vi.mocked(auditLog);
 const mockValidateUrl = vi.mocked(validateUrl);
@@ -245,5 +245,23 @@ describe("apiCall - destination allowlist", () => {
     // ...and the template is left untouched (no stringified function leaked in).
     const sentHeaders = mockFetch.mock.calls[0][1].headers;
     expect(sentHeaders["X-Test"]).toBe("{{constructor}}");
+  });
+});
+
+describe("ApiCallSchema - timeout_ms bounds", () => {
+  const base = { project_dir: "/fake/project", url: "https://example.com" };
+
+  it("defaults to 30000 when omitted", () => {
+    expect(ApiCallSchema.parse(base).timeout_ms).toBe(30000);
+  });
+
+  it("rejects zero, negative, and non-integer timeouts", () => {
+    for (const timeout_ms of [0, -1, 1.5]) {
+      expect(ApiCallSchema.safeParse({ ...base, timeout_ms }).success).toBe(false);
+    }
+  });
+
+  it("accepts a positive integer timeout", () => {
+    expect(ApiCallSchema.safeParse({ ...base, timeout_ms: 5000 }).success).toBe(true);
   });
 });

--- a/src/tools/api-call.ts
+++ b/src/tools/api-call.ts
@@ -29,6 +29,8 @@ export const ApiCallSchema = z.object({
     .describe("Env key to use as Bearer token"),
   timeout_ms: z
     .number()
+    .int()
+    .positive()
     .optional()
     .default(30000)
     .describe("Request timeout in milliseconds"),

--- a/src/tools/run-with-env.test.ts
+++ b/src/tools/run-with-env.test.ts
@@ -3,6 +3,7 @@ import { loadEnv } from "../env-loader.js";
 import { loadMyCnf } from "../mycnf-loader.js";
 import { validateProjectDir } from "../security/path-validator.js";
 import { auditLog } from "../security/audit.js";
+import { RunWithEnvSchema } from "./run-with-env.js";
 
 vi.mock("../env-loader.js", () => ({ loadEnv: vi.fn() }));
 vi.mock("../mycnf-loader.js", () => ({ loadMyCnf: vi.fn() }));
@@ -97,5 +98,23 @@ describe("runWithEnv with include_mycnf", () => {
     expect(r.stdout).toContain("[REDACTED:client.password]");
     expect(r.stdout).not.toContain("envtoken999");
     expect(r.stdout).not.toContain("cnfpass888");
+  });
+});
+
+describe("RunWithEnvSchema - timeout_ms bounds", () => {
+  const base = { project_dir: "/tmp", command: "echo hi" };
+
+  it("defaults to 30000 when omitted", () => {
+    expect(RunWithEnvSchema.parse(base).timeout_ms).toBe(30000);
+  });
+
+  it("rejects zero, negative, and non-integer timeouts", () => {
+    for (const timeout_ms of [0, -1, 1.5]) {
+      expect(RunWithEnvSchema.safeParse({ ...base, timeout_ms }).success).toBe(false);
+    }
+  });
+
+  it("accepts a positive integer timeout", () => {
+    expect(RunWithEnvSchema.safeParse({ ...base, timeout_ms: 5000 }).success).toBe(true);
   });
 });

--- a/src/tools/run-with-env.ts
+++ b/src/tools/run-with-env.ts
@@ -20,6 +20,8 @@ export const RunWithEnvSchema = z.object({
     .describe("Specific env keys to inject (default: all)"),
   timeout_ms: z
     .number()
+    .int()
+    .positive()
     .optional()
     .default(30000)
     .describe("Command timeout in milliseconds"),


### PR DESCRIPTION
## What

`timeout_ms` on both `api_call` and `run_with_env` was `z.number().optional().default(30000)` — it accepted `0`, negatives, and non-integer/fractional values. Those flow straight into `setTimeout(controller.abort, ...)` (api_call) and the exec `timeout` option (run_with_env), where a `0` or negative degenerates into "abort essentially immediately" and fractions are silently coerced.

This adds `.int().positive()` to both schemas so an out-of-range value is rejected at the MCP boundary with a clear validation error rather than producing a degenerate timeout.

## Scope

- `src/tools/api-call.ts` — `timeout_ms` → `.int().positive()`
- `src/tools/run-with-env.ts` — same
- Schema regression tests on each tool: default is `30000`; `0`, `-1`, `1.5` rejected; positive integer accepted.

The default (30000) and all normal values are unaffected — this only tightens the rejected set.

Follow-up to the bot-review note (b) on #53.

## Verification

- `npm run build` — clean (0 TS errors)
- `npx vitest run` — 169/169 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)