### PR TITLE
Re-validate every redirect hop in api_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- `api_call` now follows redirects itself instead of letting `fetch` do it. Every hop is re-checked against the SSRF guard and the destination allowlist, and the resolved IP is re-pinned for the new host. Previously only the first request was validated, so a `302` could send an injected secret to an internal address such as `169.254.169.254` or to a host outside `SECURE_API_ALLOWED_HOSTS`. Redirect chains are capped at 5 hops; `303` (and `POST` under `301`/`302`) downgrade to `GET` and drop the body, while `307`/`308` preserve both.
+
 ## [1.1.5] - 2026-08-04
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A secret can only be protected if you control where it goes. Both tools can send
 
 - **`get_env_keys(project_dir)`** — Returns key names from `.env`. No values exposed.
 - **`run_with_env(project_dir, command, env_keys?, timeout_ms?, include_mycnf?)`** — Runs a shell command with `.env` vars injected. Output is sanitized — secret values replaced with `[REDACTED:KEY_NAME]`. Set `include_mycnf` to also sanitize MySQL credentials from `.my.cnf` in command output.
-- **`api_call(project_dir, url, method?, headers?, body?, auth_env_key?, timeout_ms?)`** — HTTP request with secret injection. `auth_env_key` adds a Bearer token. Headers support `{{KEY_NAME}}` template syntax. When a secret is injected, the destination host is checked against `SECURE_API_ALLOWED_HOSTS` (see below). Times out after `timeout_ms` (default 30s).
+- **`api_call(project_dir, url, method?, headers?, body?, auth_env_key?, timeout_ms?)`** — HTTP request with secret injection. `auth_env_key` adds a Bearer token. Headers support `{{KEY_NAME}}` template syntax. When a secret is injected, the destination host is checked against `SECURE_API_ALLOWED_HOSTS` (see below). Redirects are followed manually, up to 5 hops, with the SSRF guard and the allowlist re-applied to every hop. Times out after `timeout_ms` (default 30s).
 - **`read_mycnf(project_dir, section?)`** — Reads MySQL `.my.cnf` configuration. Returns section names and safe fields (`port`, `database`, `socket`) with credentials (`user`, `password`, `host`) redacted as `[REDACTED:section.field]`. Checks `~/.my.cnf` and project-local `.my.cnf`.
 - **`sync_env_example(project_dir)`** — Generates/updates `.env.example` from `.env`. Preserves comments and structure, strips values, uses smart placeholders.
 

--- a/src/tools/api-call.test.ts
+++ b/src/tools/api-call.test.ts
@@ -265,3 +265,148 @@ describe("ApiCallSchema - timeout_ms bounds", () => {
     expect(ApiCallSchema.safeParse({ ...base, timeout_ms: 5000 }).success).toBe(true);
   });
 });
+
+describe("apiCall - redirects", () => {
+  // clearAllMocks leaves *Once queues intact, so a test that returns early
+  // would hand its unused responses to the next one.
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockValidateUrl.mockReset();
+    mockValidateUrl.mockResolvedValue({
+      allowed: true,
+      resolvedIp: "93.184.216.34",
+    });
+  });
+
+  /** Builds a fetch response; `location` makes it a redirect. */
+  const reply = (status: number, location?: string, body = "OK") => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+    headers: {
+      get: (name: string) =>
+        location && name.toLowerCase() === "location" ? location : null,
+      forEach: vi.fn(),
+    },
+  });
+
+  it("never lets fetch follow redirects itself", async () => {
+    mockFetch.mockResolvedValueOnce(reply(200));
+    await apiCall({ project_dir: "/fake/project", url: "https://example.com" });
+    expect(mockFetch.mock.calls[0][1].redirect).toBe("manual");
+  });
+
+  it("revalidates each hop against the SSRF guard", async () => {
+    mockFetch
+      .mockResolvedValueOnce(reply(302, "http://169.254.169.254/latest/meta-data/"))
+      .mockResolvedValueOnce(reply(200, undefined, "CREDENTIALS"));
+    mockValidateUrl
+      .mockResolvedValueOnce({ allowed: true, resolvedIp: "93.184.216.34" })
+      .mockResolvedValueOnce({ allowed: false, reason: "private IP blocked" });
+
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      auth_env_key: "MY_TOKEN",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.body).toContain("private IP blocked");
+    expect(result.body).not.toContain("CREDENTIALS");
+    // The second request was never made.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockAuditLog).toHaveBeenCalledWith("api_call", { status: "blocked" });
+  });
+
+  it("blocks a redirect that would carry a secret off the allowlist", async () => {
+    process.env.SECURE_API_ALLOWED_HOSTS = "example.com";
+    mockFetch.mockResolvedValueOnce(reply(302, "https://evil.example/collect"));
+
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      auth_env_key: "MY_TOKEN",
+    });
+
+    delete process.env.SECURE_API_ALLOWED_HOSTS;
+    expect(result.status).toBe(0);
+    expect(result.body).toContain("evil.example");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows an allowed redirect and pins the new host's IP", async () => {
+    mockFetch
+      .mockResolvedValueOnce(reply(302, "https://example.com/moved"))
+      .mockResolvedValueOnce(reply(200, undefined, "ARRIVED"));
+    mockValidateUrl
+      .mockResolvedValueOnce({ allowed: true, resolvedIp: "93.184.216.34" })
+      .mockResolvedValueOnce({ allowed: true, resolvedIp: "93.184.216.35" });
+
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toBe("ARRIVED");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1][0]).toBe("https://example.com/moved");
+  });
+
+  it("resolves a relative Location against the current URL", async () => {
+    mockFetch
+      .mockResolvedValueOnce(reply(302, "/moved"))
+      .mockResolvedValueOnce(reply(200));
+    await apiCall({ project_dir: "/fake/project", url: "https://example.com/a/b" });
+    expect(mockFetch.mock.calls[1][0]).toBe("https://example.com/moved");
+  });
+
+  it("downgrades POST to GET and drops the body on a 303", async () => {
+    mockFetch
+      .mockResolvedValueOnce(reply(303, "https://example.com/done"))
+      .mockResolvedValueOnce(reply(200));
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      method: "POST",
+      body: "payload",
+    });
+    expect(mockFetch.mock.calls[1][1].method).toBe("GET");
+    expect(mockFetch.mock.calls[1][1].body).toBeUndefined();
+  });
+
+  it("preserves method and body across a 307", async () => {
+    mockFetch
+      .mockResolvedValueOnce(reply(307, "https://example.com/done"))
+      .mockResolvedValueOnce(reply(200));
+    await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+      method: "POST",
+      body: "payload",
+    });
+    expect(mockFetch.mock.calls[1][1].method).toBe("POST");
+    expect(mockFetch.mock.calls[1][1].body).toBe("payload");
+  });
+
+  it("stops after the redirect cap rather than looping", async () => {
+    mockFetch.mockResolvedValue(reply(302, "https://example.com/next"));
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+    });
+    expect(result.status).toBe(0);
+    expect(result.body).toContain("exceeded 5 redirects");
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it("returns a 3xx without a Location as the final response", async () => {
+    mockFetch.mockResolvedValueOnce(reply(302, undefined, "no location"));
+    const result = await apiCall({
+      project_dir: "/fake/project",
+      url: "https://example.com",
+    });
+    expect(result.status).toBe(302);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tools/api-call.ts
+++ b/src/tools/api-call.ts
@@ -70,6 +70,28 @@ interface ApiCallResult {
   warnings?: string[];
 }
 
+/** Redirect hops followed before giving up. */
+const MAX_REDIRECTS = 5;
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Applies the method and body rewrite a redirect implies.
+ *
+ * 303 always becomes GET. 301 and 302 keep the method in the spec but every
+ * real client downgrades POST to GET, and servers expect that. 307 and 308
+ * exist precisely to preserve the method, so they are left alone.
+ */
+function redirectedRequest(
+  status: number,
+  method: string,
+  body: string | undefined
+): { method: string; body: string | undefined } {
+  if (status === 307 || status === 308) return { method, body };
+  if (status === 303 || method === "POST") return { method: "GET", body: undefined };
+  return { method, body };
+}
+
 export async function apiCall(
   args: z.infer<typeof ApiCallSchema>
 ): Promise<ApiCallResult> {
@@ -109,53 +131,110 @@ export async function apiCall(
   // Enforced (SECURE_API_ALLOWED_HOSTS set): block non-matching hosts.
   // Unenforced (unset): allow but warn so an unexpected destination is visible.
   const warnings: string[] = [];
-  if (injectedKeys.size > 0) {
-    const policy = getHostPolicy();
-    const host = new URL(args.url).hostname;
+  const policy = getHostPolicy();
+  const checkDestination = (host: string): string | null => {
+    if (injectedKeys.size === 0) return null;
     if (policy.enforced) {
-      if (!policy.allows(host)) {
-        auditLog("api_call", { status: "blocked" });
-        return {
-          status: 0,
-          headers: {},
-          body: `Request blocked: host '${host}' is not in SECURE_API_ALLOWED_HOSTS — refusing to send secrets to an unapproved destination`,
-        };
-      }
-    } else {
-      // No allowlist configured — secret still goes out, but make it visible.
-      warnings.push(
-        `Secret(s) sent to '${host}'. Set SECURE_API_ALLOWED_HOSTS to restrict where secrets may be sent.`
-      );
+      return policy.allows(host)
+        ? null
+        : `host '${host}' is not in SECURE_API_ALLOWED_HOSTS — refusing to send secrets to an unapproved destination`;
     }
+    // No allowlist configured — secret still goes out, but make it visible.
+    warnings.push(
+      `Secret(s) sent to '${host}'. Set SECURE_API_ALLOWED_HOSTS to restrict where secrets may be sent.`
+    );
+    return null;
+  };
+
+  const blocked = checkDestination(new URL(args.url).hostname);
+  if (blocked) {
+    auditLog("api_call", { status: "blocked" });
+    return { status: 0, headers: {}, body: `Request blocked: ${blocked}` };
   }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), args.timeout_ms);
 
   // Pin the resolved IP at the socket layer to close the DNS rebinding
   // TOCTOU window. The URL keeps the original hostname (preserving TLS
   // SNI and cert validation), but undici's lookup callback returns the
   // IP that validateUrl already checked instead of re-resolving DNS.
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), args.timeout_ms);
-
-  const fetchOptions: Record<string, unknown> = {
-    method: args.method,
-    headers,
-    body: args.body,
-    signal: controller.signal,
-  };
-  if (urlCheck.resolvedIp) {
-    const pinnedIp = urlCheck.resolvedIp;
-    fetchOptions.dispatcher = new Agent({
-      connect: {
-        lookup: (_hostname, _options, cb) => {
-          cb(null, [{ address: pinnedIp, family: pinnedIp.includes(":") ? 6 : 4 }]);
-        },
-      },
-    });
-  }
+  const pinnedDispatcher = (ip: string | undefined): Agent | undefined =>
+    ip === undefined
+      ? undefined
+      : new Agent({
+          connect: {
+            lookup: (_hostname, _options, cb) => {
+              cb(null, [{ address: ip, family: ip.includes(":") ? 6 : 4 }]);
+            },
+          },
+        });
 
   let response: Response;
+  let currentUrl = args.url;
+  let currentIp = urlCheck.resolvedIp;
+  let method: string = args.method;
+  let body = args.body;
+
   try {
-    response = await fetch(args.url, fetchOptions);
+    // Redirects are followed by hand. Letting fetch follow them would skip
+    // both the SSRF check and the allowlist on every hop after the first, so
+    // a 302 to an internal address or an unapproved host would carry the
+    // injected secret straight there. The pinned dispatcher is per-connection
+    // and would not cover the new host either.
+    for (let hop = 0; ; hop++) {
+      const dispatcher = pinnedDispatcher(currentIp);
+      response = await fetch(currentUrl, {
+        method,
+        headers,
+        body,
+        signal: controller.signal,
+        redirect: "manual",
+        ...(dispatcher ? { dispatcher } : {}),
+      } as RequestInit);
+
+      if (!REDIRECT_STATUSES.has(response.status)) break;
+
+      const location = response.headers.get("location");
+      if (!location) break;
+
+      if (hop >= MAX_REDIRECTS) {
+        auditLog("api_call", { status: "blocked" });
+        return {
+          status: 0,
+          headers: {},
+          body: `Request blocked: exceeded ${MAX_REDIRECTS} redirects`,
+          ...(warnings.length > 0 ? { warnings } : {}),
+        };
+      }
+
+      const nextUrl = new URL(location, currentUrl).toString();
+      const nextCheck = await validateUrl(nextUrl);
+      if (!nextCheck.allowed) {
+        auditLog("api_call", { status: "blocked" });
+        return {
+          status: 0,
+          headers: {},
+          body: `Request blocked: redirect to ${nextUrl} — ${nextCheck.reason}`,
+          ...(warnings.length > 0 ? { warnings } : {}),
+        };
+      }
+
+      const nextBlocked = checkDestination(new URL(nextUrl).hostname);
+      if (nextBlocked) {
+        auditLog("api_call", { status: "blocked" });
+        return {
+          status: 0,
+          headers: {},
+          body: `Request blocked: redirect to ${nextBlocked}`,
+          ...(warnings.length > 0 ? { warnings } : {}),
+        };
+      }
+
+      ({ method, body } = redirectedRequest(response.status, method, body));
+      currentUrl = nextUrl;
+      currentIp = nextCheck.resolvedIp;
+    }
   } catch (err) {
     auditLog("api_call", { status: "error" });
     const message =


### PR DESCRIPTION
## The hole

`api_call` called `fetch` with the default `redirect: "follow"`, so only the **first** request was ever validated. Everything after that was unchecked:

- **SSRF guard bypassed.** `validateUrl` ran once, against the URL the caller supplied. A `302` to `http://169.254.169.254/latest/meta-data/` was followed without a second look.
- **Allowlist bypassed.** The `SECURE_API_ALLOWED_HOSTS` check also ran once, before the redirect. An approved host could bounce an injected secret to any destination it liked.
- **IP pin didn't carry.** The pinned-IP dispatcher is per-connection, so the redirect target got a fresh DNS resolution with nothing checking the result — reopening the rebinding window the pin exists to close.

Worth noting the shape of it: the guards weren't wrong, they just only covered hop one. Any server on an allowlisted host — or anyone who could get a `302` out of one — could reach past all three.

## The fix

Redirects are followed by hand with `redirect: "manual"`. Each hop re-runs `validateUrl`, re-checks the allowlist when a secret was injected, and re-pins the IP for the new host. Chains cap at 5 hops.

Method rewriting follows what clients actually do rather than what the spec says: `303` becomes `GET` and drops the body, as does `POST` under `301`/`302`, while `307`/`308` preserve both.

## Tests

9 new, 196 passing. The two that pin the actual attack:

- a `302` to the metadata endpoint is blocked, and `fetch` is never called a second time
- a `302` off the allowlist is blocked with the secret never sent

Plus relative `Location` resolution, the hop cap, `3xx` with no `Location`, and the method-rewrite rules per status.

## One test-harness note

`vi.clearAllMocks()` doesn't drain `mockResolvedValueOnce` queues, so a test that returns early hands its unused responses to the next test. That silently broke two of these before I added a local `mockReset()`. Worth knowing for anything else in this file that mocks `fetch` more than once.
